### PR TITLE
fix(ci): desbloquear el gate de CVE y el bake desde la ref de la PR

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -140,6 +140,10 @@ jobs:
       - name: Bake y push (app + worker + proxy)
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
+          # Sin esto bake construye desde el contexto git REMOTO
+          # (…git#refs/pull/N/merge), que GitHub borra al cerrar la PR: una
+          # reejecución posterior muere con «repository does not contain ref».
+          source: .
           files: docker/docker-bake.hcl
           targets: default
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,10 @@ jobs:
       - name: Bake (app + worker + proxy)
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
+          # Sin esto bake construye desde el contexto git REMOTO
+          # (…git#refs/pull/N/merge), que GitHub borra al cerrar la PR: una
+          # reejecución posterior muere con «repository does not contain ref».
+          source: .
           files: docker/docker-bake.hcl
           targets: default
           push: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,15 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 RUN apk add --no-cache su-exec
+
+# npm no pinta nada en runtime: la app arranca con `node src/server.js`, el
+# worker con `node src/worker.js` y el entrypoint no lo llama. Pero sus
+# dependencias empaquetadas (tar, brace-expansion, ip-address, picomatch,
+# sigstore) sí cuentan para Trivy, y son las que tumban el gate de CVE del
+# CD sin que ninguna sea nuestra: `npm audit --omit=dev` da cero. Se borra
+# el código vulnerable en vez de excluir la ruta del análisis, que además
+# recorta superficie: ninguna imagen publicada puede instalar paquetes.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY migrations ./migrations

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -13,7 +13,18 @@
 # Con la configuración horneada aquí, el stack no depende de nada del host: se
 # despliega eligiendo el compose y pegando el .env, que es como se opera.
 
-FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+# La rama 1.27 dejó de reconstruirse: su tag sigue apuntando al mismo digest
+# sobre Alpine 3.21, con 35 CVE altas/críticas acumuladas (dos de OpenSSL).
+# 1.29 es la rama viva, sobre Alpine 3.23, y sigue trayendo `secure_link`,
+# que es el módulo del que depende la firma de segmento.
+FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
+
+# La imagen oficial se reconstruye más despacio de lo que Alpine publica
+# parches, así que al construir arrastra paquetes con CVE altas ya
+# corregidas aguas arriba (openssl, curl, expat, libxml2, nghttp2…). Este
+# upgrade las recoge. Es la única capa no reproducible de las tres
+# imágenes, y se acepta a propósito: es un proxy que termina TLS.
+RUN apk upgrade --no-cache
 
 # Lo pasa el bake para las tres imágenes; aquí sólo sirve para que la etiqueta
 # de versión de la imagen coincida con la de app y worker.


### PR DESCRIPTION
Sin esto no se puede mergear nada: el gate de Trivy está rojo en las 10 PR de dependabot abiertas y en el CD de main.

## Qué pasaba

La base de datos de CVE del 18 de agosto marcó seis vulnerabilidades (`tar` CRITICAL, `brace-expansion`, `ip-address`, `picomatch`, `sigstore`). **Ninguna es de MoodleShield**: salen de `usr/local/lib/node_modules/npm/node_modules/…`, el npm que viene dentro de `node:22-alpine`.

- `npm audit --omit=dev` → 0 vulnerabilidades.
- De los cinco paquetes sólo `ip-address` está en nuestro árbol de producción, y main ya lo tiene en 10.4.0 (el parche era 10.3.1). El 10.1.0 que reportaba Trivy es la copia que npm empaqueta aparte.

**Consecuencia real:** en el CD del merge de #20 las imágenes se publicaron y se firmaron (pasos 7 y 9 en verde), pero el paso 13 —el bump de `infra/test/compose.yml`— quedó en `skipped`. **Test no llegó a desplegarse.**

## Qué cambia

**1. Fuera npm de las imágenes de runtime.** No se usa: `app` arranca con `node src/server.js`, `worker` con `node src/worker.js`, y `entrypoint.sh` no lo llama. Se borra el código vulnerable en vez de excluir la ruta con `skip-dirs`, y de paso ninguna imagen publicada puede ya instalar paquetes.

**2. El proxy, que tenía un problema propio y peor.** El gate nunca llegó a enseñarlo porque moría antes en `app`: `nginx:1.27-alpine` **dejó de reconstruirse** —su tag sigue apuntando al mismo digest— y acumulaba **35 CVE altas/críticas sobre Alpine 3.21, dos de ellas CRITICAL en OpenSSL**. Sube a `1.29-alpine` (Alpine 3.23) y actualiza paquetes en el build, porque la imagen oficial va por detrás de los parches de Alpine.

**3. `source: .` en los dos pasos de bake.** Es el fallo `repository does not contain ref refs/pull/20/merge`: bake construye por defecto desde el contexto git **remoto**, que GitHub borra al cerrar la PR, así que cualquier reejecución posterior muere. Sigue haciendo falta en la v7 de #9 (v7 fusiona `workdir` dentro de `source`, pero el defecto remoto no cambia).

## Verificación en local

Trivy 0.70 con la base de datos del día, mismos flags que el CD (`--severity CRITICAL,HIGH --pkg-types os,library --exit-code 1`):

| imagen | antes | ahora |
|---|---|---|
| `app` | 6 CVE (1 CRITICAL) | **exit 0** |
| `worker` | sin escanear (el job moría antes) | **exit 0** |
| `proxy` | **35 CVE (2 CRITICAL)** | **exit 0** |

El proxy además responde `204` en `/_proxy-healthz`, `nginx -t` pasa y `secure_link` —la firma de segmento— sigue compilado en 1.29.8.

## Después de esto

Quedan mergeables las 10 PR de dependabot, en este orden por dependencias entre ellas: #1 antes que #4 (pino-http 11 es «update for pino@10») y #6 antes que #5 (@eslint/js 10 exige eslint 10). La #16 (pdfjs-dist) es obsoleta: main ya está en 6.2.108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)