### PR TITLE
ci(entornos): una rama por entorno, para que un merge no pueda tocar producción

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
+
+# Las actualizaciones entran por `test`, como cualquier otro cambio: nada se
+# mergea directamente contra producción (ADR-028).
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: test
     schedule:
       interval: weekly
       day: monday
@@ -15,12 +19,14 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: test
     schedule:
       interval: monthly
     labels: [dependencias, ci]
 
   - package-ecosystem: docker
     directory: /docker
+    target-branch: test
     schedule:
       interval: monthly
     labels: [dependencias, docker]

--- a/.github/workflows/cd-promote.yml
+++ b/.github/workflows/cd-promote.yml
@@ -1,5 +1,13 @@
 name: 'CD · tag vX.Y.Z: promover la misma imagen a producción'
 
+# El tag se crea sobre `test`, sobre un commit YA desplegado y probado ahí.
+# Promocionar es dos cosas, y ninguna es construir:
+#   1. Re-etiquetar el mismo digest sha-<commit> como vX.Y.Z.
+#   2. Avanzar `main` HASTA ese commit y escribir la etiqueta en
+#      infra/prod/compose.yml.
+# Portainer de producción sigue `main`, que por tanto sólo se mueve aquí:
+# ningún merge de trabajo puede tocar producción (ADR-028).
+
 # Promoción a producción SIN reconstruir: `docker buildx imagetools create`
 # re-etiqueta el digest que ya rodó en test como vX.Y.Z + latest. Ni Node, ni
 # tests, ni build: el commit ya se verificó y construyó al entrar en main.
@@ -24,6 +32,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          # Historia completa: este job mueve `main` hasta el commit
+          # etiquetado, y con un checkout superficial no hay base de merge.
+          fetch-depth: 0
 
       - name: Resolver commit y etiquetas
         id: meta
@@ -34,6 +46,7 @@ jobs:
           # apuntar al objeto tag y no al commit.
           commit=$(git rev-parse HEAD)
           echo "repo=$repo"                    >> "$GITHUB_OUTPUT"
+          echo "commit=$commit"                >> "$GITHUB_OUTPUT"
           echo "sha_tag=sha-${commit::7}"      >> "$GITHUB_OUTPUT"
           echo "version=${GITHUB_REF_NAME}"    >> "$GITHUB_OUTPUT"
 
@@ -53,7 +66,7 @@ jobs:
           for img in app worker proxy; do
             src="ghcr.io/${REPO}/${img}:${SRC}"
             if ! docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
-              echo "::error::No existe ${src}. Sólo se pueden etiquetar commits que hayan pasado por main (cd-main publica su imagen sha-*). Haz push a main primero."
+              echo "::error::No existe ${src}. Sólo se etiquetan commits que hayan pasado por \`test\` (cd-test publica su imagen sha-*). Un tag sobre un commit sin ensayar en test no se promociona."
               exit 1
             fi
             docker buildx imagetools create \
@@ -67,27 +80,43 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           REPO: ${{ steps.meta.outputs.repo }}
+          TAG_SHA: ${{ steps.meta.outputs.commit }}
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Mismo patrón que cd-main: partir siempre de la punta real de main y
+          # Mismo patrón que cd-test: partir siempre de la punta real de main y
           # reintentar, en vez de rebasar un cambio sobre la misma línea.
           for intento in 1 2 3; do
             git fetch origin main
             git checkout -B main origin/main
 
+            # Producción corre EL MISMO árbol que se ensayó en test, no una
+            # mezcla: main avanza hasta el commit etiquetado antes de escribir
+            # la etiqueta de imagen. Si ya lo contiene, no hay nada que traer.
+            if ! git merge-base --is-ancestor "$TAG_SHA" HEAD; then
+              git merge --no-ff --no-edit -m "promote: ${VERSION} [skip ci]" "$TAG_SHA"
+            fi
+
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/app:.*$|    image: ghcr.io/jamataran/moodleshield/app:${VERSION}|"       infra/prod/compose.yml
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/worker:.*$|    image: ghcr.io/jamataran/moodleshield/worker:${VERSION}|" infra/prod/compose.yml
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/proxy:.*$|    image: ghcr.io/jamataran/moodleshield/proxy:${VERSION}|"   infra/prod/compose.yml
 
+            # El commit del bump es condicional; el push NO, porque el merge de
+            # arriba también tiene que llegar a main aunque la etiqueta ya fuera
+            # la correcta.
             if git diff --quiet -- infra/prod/compose.yml; then
-              echo "Sin cambios (prod ya estaba en ${VERSION})"; exit 0
+              echo "La etiqueta de prod ya era ${VERSION}"
+            else
+              git add infra/prod/compose.yml
+              git commit -m "deploy(prod): ${VERSION} [skip ci]"
             fi
 
-            git add infra/prod/compose.yml
-            git commit -m "deploy(prod): ${VERSION} [skip ci]"
+            if git diff --quiet origin/main HEAD; then
+              echo "main ya estaba en ${VERSION}: nada que empujar"; exit 0
+            fi
+
             if git push origin main; then
               echo "Desplegado ${VERSION} en prod"; exit 0
             fi

--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -1,22 +1,24 @@
-name: 'CD · main: publicar imágenes y desplegar en test'
+name: 'CD · test: publicar imágenes y desplegar en test'
 
-# Cada push a main: verifica, construye UNA vez, publica :sha-<commit> y :edge,
-# y escribe la etiqueta directamente en infra/test/compose.yml. Portainer
-# (GitOps) sólo necesita leer el Compose para redesplegar test.
+# Cada push a `test`: verifica, construye UNA vez, publica :sha-<commit> y
+# :edge, y escribe la etiqueta en infra/test/compose.yml DE LA PROPIA RAMA
+# `test`. Portainer de test sigue esa rama (GitOps) y sólo necesita leer el
+# Compose para redesplegar.
 #
-# La promoción a prod NO pasa por aquí: cd-promote.yml re-etiqueta este mismo
-# digest cuando se crea un tag vX.Y.Z. Misma imagen hacia arriba.
+# `main` es producción y no se toca desde aquí: la promoción es crear un tag
+# vX.Y.Z sobre `test`, y cd-promote.yml re-etiqueta ESTE MISMO digest y mueve
+# main. Nunca se reconstruye para subir de entorno (ADR-028).
 
 on:
   push:
-    branches: [main]
+    branches: [test]
     paths-ignore: ['docs/**', '**/*.md', 'LICENSE', 'infra/local/**', '.idea/**']
   workflow_dispatch:
 
 # Los despliegues se encolan, no se cancelan: un deploy a medias es peor que
 # uno tardío.
 concurrency:
-  group: cd-main
+  group: cd-test
   cancel-in-progress: false
 
 permissions:
@@ -209,10 +211,10 @@ jobs:
           # aterrizó otro push, hacer el sed sobre esa base antigua y rebasar
           # después provoca conflicto en las MISMAS líneas (image:) y el deploy
           # falla sin posibilidad de recuperarlo con un re-run. Por eso se parte
-          # siempre de la punta real de main, y se reintenta si nos adelantan.
+          # siempre de la punta real de `test`, y se reintenta si nos adelantan.
           for intento in 1 2 3; do
-            git fetch origin main
-            git checkout -B main origin/main
+            git fetch origin test
+            git checkout -B test origin/test
 
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/app:.*$|    image: ghcr.io/jamataran/moodleshield/app:${SHA_TAG}|"       infra/test/compose.yml
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/worker:.*$|    image: ghcr.io/jamataran/moodleshield/worker:${SHA_TAG}|" infra/test/compose.yml
@@ -229,11 +231,11 @@ jobs:
             # Los pushes con GITHUB_TOKEN no disparan workflows; el [skip ci] es
             # el cinturón además de los tirantes.
             git commit -m "deploy(test): ${SHA_TAG} [skip ci]"
-            if git push origin main; then
+            if git push origin test; then
               echo "Desplegado ${SHA_TAG} en test"; exit 0
             fi
-            echo "main se movió durante el push; reintento $intento"
-            git reset --hard origin/main
+            echo "test se movió durante el push; reintento $intento"
+            git reset --hard origin/test
           done
           echo "::error::No se pudo empujar el bump tras 3 intentos"; exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: 'CI · PR: validar código, infraestructura y build'
 
-# Sólo en pull requests. Los pushes a main los cubre cd-main.yml (que ya
+# Sólo en pull requests. Los pushes a `test` los cubre cd-test.yml (que ya
 # verifica antes de publicar): así cada commit se construye UNA vez, no dos.
 
 on:
@@ -16,6 +16,37 @@ permissions:
   contents: read
 
 jobs:
+  # El 18 de agosto de 2026 una rama de features traía cambios en
+  # infra/prod/compose.yml; al mergear, Portainer los recogió e intentó
+  # redesplegar producción con un Compose que exigía secretos que aún no
+  # existían. Producción no se toca trabajando: se toca al promocionar, y de
+  # eso se encarga cd-promote.yml (ADR-028). Aquí se cierra la puerta.
+  frontera-entornos:
+    name: Frontera entre entornos
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.base_ref == 'test'
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+
+      - name: infra/prod sólo cambia al promocionar
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE"
+          tocados=$(git diff --name-only "origin/${BASE}...HEAD" -- infra/prod/)
+          if [ -n "$tocados" ]; then
+            echo "::error::Esta PR cambia infra/prod/, y hacia \`test\` eso no se permite:"
+            echo "$tocados"
+            echo "Producción sólo se mueve promocionando (tag vX.Y.Z sobre \`test\`)."
+            echo "Si el cambio es del Compose de producción, va en la PR de promoción."
+            exit 1
+          fi
+          echo "Sin cambios en infra/prod/."
+
   verify:
     name: Lint, tests e infraestructura
     runs-on: ubuntu-latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | Documento | Qué resuelve |
 |---|---|
 | [`arquitectura.md`](arquitectura.md) | Vista general, árbol de medios, el camino de un visionado y el de una subida, modelo de datos, tabla de endpoints, modelo de seguridad capa por capa |
-| [`decisiones.md`](decisiones.md) | ADR-001…026. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
+| [`decisiones.md`](decisiones.md) | ADR-001…028. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
 | [`revision-seguridad-2026-08-10.md`](revision-seguridad-2026-08-10.md) | **Estado de seguridad actual**: qué está sólo en rama, qué consta en producción, hallazgos nuevos y gates de despliegue |
 | [`auditoria-seguridad-contenido-y-plan.md`](auditoria-seguridad-contenido-y-plan.md) | **Auditoría de seguridad del contenido**: modelo de amenaza, 16 hallazgos priorizados, arquitectura objetivo y plan por fases |
 | [`auditoria-seguridad.md`](auditoria-seguridad.md) | **Segunda auditoría (V-01…V-37)** y, en su [§8](auditoria-seguridad.md#8-notas-de-implementación--claude-fable-5), el registro de qué se implementó, qué se difirió y por qué en las dos iteraciones de endurecimiento |

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -961,3 +961,61 @@ suyo, más holgado y todavía acotado. Cada importación deja un evento
 **Cambiar `ADMIN_LIBRARY_OWNER_SUB` con contenido ya importado lo esconde**: las
 carpetas y el material siguen en la base de datos, pero cuelgan de un
 propietario que ya no se consulta. Se decide antes de importar nada.
+
+## ADR-028 · El entorno es la rama: `test` y `main` son dos entornos, no dos etapas de revisión
+
+**Estado**: aceptada · **Fecha**: 2026-08
+
+**Contexto.** Los dos stacks de Portainer seguían la **misma** referencia,
+`refs/heads/main`, y se distinguían sólo por el `Compose path`:
+`infra/prod/compose.yml` uno, `infra/test/compose.yml` el otro. Con ese montaje
+no existe frontera entre probar y publicar. Cualquier commit en `main` llega a
+los dos entornos a la vez, y basta con que una rama de trabajo toque el Compose
+de producción para que producción se redespliegue al mergear, sin que nadie lo
+haya decidido.
+
+Ocurrió el 18 de agosto de 2026. Una rama de features traía, junto a su trabajo,
+el `infra/prod/compose.yml` endurecido de la revisión de seguridad. Al mergear,
+Portainer lo recogió e intentó redesplegar producción con un Compose que exigía
+dos secretos que aún no existían en su `.env`, `DB_APP_PASSWORD` y
+`DB_WORKER_PASSWORD`. Falló al interpolar, antes de tocar ningún contenedor, así
+que el servicio siguió en pie; pero el margen entre eso y una caída real lo
+puso el azar, no el diseño. La «Transición obligatoria desde `v1.0.5`» de
+[`revision-seguridad-2026-08-10.md`](revision-seguridad-2026-08-10.md) son nueve
+pasos con copia de seguridad y reinserción por Deep Linking: exactamente el tipo
+de cosa que no puede dispararla un merge.
+
+**Decisión.** Una rama por entorno, y cada Portainer sigue la suya.
+
+- `test` es el entorno de pruebas. **Todo** se mergea aquí: features y también
+  dependabot, que apunta a esta rama. `cd-test.yml` verifica, construye una vez,
+  publica `sha-<commit>`, lo firma, lo escanea y escribe la etiqueta en
+  `infra/test/compose.yml` **de la propia rama `test`**.
+- `main` es producción. **No se mergea a mano.** Sólo la mueve `cd-promote.yml`
+  al crear un tag `vX.Y.Z` sobre un commit de `test`: re-etiqueta ese mismo
+  digest, avanza `main` hasta el commit etiquetado y escribe
+  `infra/prod/compose.yml`.
+
+Sigue siendo *build once, promote up*, que ya era la intención: promocionar no
+reconstruye nada. Lo que cambia es que ahora producción corre **el mismo árbol y
+el mismo digest** que se ensayaron en test, y no una mezcla del Compose de una
+rama con el código de otra.
+
+Se mantiene la organización por entorno, `infra/{test,prod}/`. Unificar los dos
+Compose en uno solo parametrizado por `.env` eliminaría la divergencia por
+construcción, pero pierde la separación visible entre lo que toca a producción y
+lo que no; con la frontera puesta en la rama, la divergencia deja de ser el
+riesgo que era.
+
+Dos cierres más, porque una convención que sólo vive en la cabeza de alguien no
+es un control:
+
+- El job `frontera-entornos` de `ci.yml` rechaza toda PR hacia `test` que toque
+  `infra/prod/`. Producción no se edita trabajando.
+- `cd-promote.yml` falla en cerrado si no existe el `:sha-<commit>` del commit
+  etiquetado: no se promociona nada que no haya pasado por test.
+
+**Cómo revertirlo.** Devolver los dos stacks de Portainer a `refs/heads/main`,
+volver a disparar `cd-test.yml` con `branches: [main]` y quitar el job
+`frontera-entornos`. La rama `test` puede quedarse donde está; no la lee nadie
+más. Conviene no hacerlo: es volver a la situación que causó el incidente.

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -409,27 +409,37 @@ las herramientas reales, migraciones idempotentes contra Postgres, validación d
 Compose, comprobación de que no hay secretos en los `.env` versionados y una construcción
 Docker sin publicar.
 
+**El entorno es la rama** (ADR-028). `test` es el entorno de pruebas y `main` es
+producción; cada Portainer sigue la suya. Todo el trabajo —features y dependabot—
+se mergea a `test`, y **a `main` no se mergea a mano nunca**: sólo lo mueve la
+promoción.
+
 Qué pasa después del merge (esto sólo aplica al repositorio canónico):
 
 ```text
-feature/* ── PR ──▶ CI ──▶ merge a main
+feature/* ── PR ──▶ CI ──▶ merge a test
                               │
-                              ├─ cd-main.yml: verifica y construye una vez
+                              ├─ cd-test.yml: verifica y construye una vez
                               ├─ publica app/worker/proxy:sha-<commit> en GHCR
-                              ├─ actualiza infra/test/compose.yml
-                              └─ Portainer detecta el commit y despliega TEST
+                              ├─ actualiza infra/test/compose.yml EN `test`
+                              └─ Portainer (refs/heads/test) despliega TEST
 
-main ── tag vX.Y.Z ──▶ cd-promote.yml
+test ── tag vX.Y.Z ──▶ cd-promote.yml
                        ├─ comprueba que existe :sha-<commit> en GHCR
                        ├─ re-etiqueta el MISMO digest como :vX.Y.Z y :latest
-                       ├─ actualiza infra/prod/compose.yml
-                       └─ Portainer despliega PROD
+                       ├─ avanza `main` HASTA el commit etiquetado
+                       ├─ actualiza infra/prod/compose.yml EN `main`
+                       └─ Portainer (refs/heads/main) despliega PROD
 ```
 
-Es *build once, promote up*: crear el tag **no reconstruye nada**, sólo re-etiqueta. El
-rollback es un `git revert` del commit de despliegue. Los commits `deploy(test): …` y
-`deploy(prod): …` son automáticos: no los edites ni los borres a mano, son lo que activa
-GitOps.
+Es *build once, promote up*: crear el tag **no reconstruye nada**, sólo re-etiqueta, y
+producción acaba corriendo el mismo digest que se ensayó en test. El rollback es un
+`git revert` del commit de despliegue. Los commits `deploy(test): …` y `deploy(prod): …`
+son automáticos: no los edites ni los borres a mano, son lo que activa GitOps.
+
+Sólo se etiqueta un commit que ya esté desplegado en test: si no existe su
+`:sha-<commit>` en GHCR, `cd-promote` falla en cerrado. Y una PR hacia `test` que
+toque `infra/prod/` la rechaza el job `frontera-entornos` de `ci.yml`.
 
 Los cambios que sólo tocan documentación, `LICENSE`, `.idea/` o `infra/local/` no publican
 imágenes ni despliegan.

--- a/infra/README.md
+++ b/infra/README.md
@@ -229,13 +229,22 @@ variable separada, `DB_BIND_ADDRESS=127.0.0.1`, para no publicarlo por accidente
 
 *Stacks → Add stack → Repository*:
 
-| Campo | Valor |
-|---|---|
-| Repository URL | `https://github.com/jamataran/moodleshield` |
-| Reference | `refs/heads/main` |
-| Compose path | `infra/prod/compose.yml` o `infra/test/compose.yml` |
-| GitOps updates | Activado; polling o webhook |
-| Environment variables | *Advanced mode* → pegar el bloque guardado |
+**Cada entorno sigue SU rama.** Es la parte que no se puede improvisar: si los dos
+stacks apuntan a la misma referencia, cualquier commit los mueve a la vez y un
+cambio pensado para pruebas entra en producción sin que nadie lo decida. Pasó el 18
+de agosto de 2026 y de ahí sale el ADR-028.
+
+| Campo | Producción | Pruebas |
+|---|---|---|
+| Repository URL | `https://github.com/jamataran/moodleshield` | igual |
+| Reference | `refs/heads/main` | `refs/heads/test` |
+| Compose path | `infra/prod/compose.yml` | `infra/test/compose.yml` |
+| GitOps updates | Activado; polling o webhook | igual |
+| Environment variables | *Advanced mode* → pegar el bloque guardado | igual |
+
+`main` sólo lo mueve `cd-promote.yml` al crear un tag `vX.Y.Z`; el trabajo del día
+a día se mergea a `test`. Comprueba las dos referencias antes de dar por buena la
+instalación: es el único campo que separa producción de pruebas.
 
 Si GHCR es privado, registra `ghcr.io` en Portainer con un token que tenga
 `read:packages`. Se descargan tres imágenes: `app`, `worker` y `proxy`.

--- a/infra/test/compose.yml
+++ b/infra/test/compose.yml
@@ -223,7 +223,7 @@ services:
         condition: service_healthy
       app:
         condition: service_healthy
-    # cd-main.yml activa el entorno mínimo a la vez que publica la imagen nueva.
+    # cd-test.yml activa el entorno mínimo a la vez que publica la imagen nueva.
     environment: *worker-env # WORKER_ENV_ACTIVATION
     volumes:
       - "${DATA_ROOT:?falta DATA_ROOT}/media:/data/media:z"

--- a/test/security/contenedores.test.js
+++ b/test/security/contenedores.test.js
@@ -153,7 +153,7 @@ for (const file of DEPLOYABLES) {
 
     if (blocks.worker.includes('*app-env # WORKER_ENV_ACTIVATION')) {
       const workflow = file.includes('/test/')
-        ? '.github/workflows/cd-main.yml'
+        ? '.github/workflows/cd-test.yml'
         : '.github/workflows/release.yml'
       const workflowText = await readFile(path.join(root, workflow), 'utf8')
       assert.match(workflowText,

--- a/test/security/supply-chain.test.js
+++ b/test/security/supply-chain.test.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 
 test('las acciones de GitHub están ancladas a commits completos', async () => {
-  const files = ['ci.yml', 'cd-main.yml', 'release.yml', 'cd-promote.yml', 'codeql.yml']
+  const files = ['ci.yml', 'cd-test.yml', 'release.yml', 'cd-promote.yml', 'codeql.yml']
   for (const file of files) {
     const text = await readFile(path.join(root, '.github/workflows', file), 'utf8')
     for (const line of text.match(/^\s*(?:-\s+)?uses:\s*[^\s]+/gm) ?? []) {
@@ -34,7 +34,7 @@ test('las imágenes base desplegables están ancladas por digest', async () => {
 })
 
 test('CD publica SBOM, provenance y firma; release verifica la firma', async () => {
-  const cd = await readFile(path.join(root, '.github/workflows/cd-main.yml'), 'utf8')
+  const cd = await readFile(path.join(root, '.github/workflows/cd-test.yml'), 'utf8')
   const release = await readFile(path.join(root, '.github/workflows/release.yml'), 'utf8')
   assert.match(cd, /\*\.attest=type=sbom/)
   assert.match(cd, /\*\.attest=type=provenance,mode=max/)
@@ -53,7 +53,7 @@ test('el CI de PR también bloquea CVE altas/críticas en las tres imágenes', a
 })
 
 test('npm ci nunca se ejecuta con un token de escritura disponible', async () => {
-  const cd = await readFile(path.join(root, '.github/workflows/cd-main.yml'), 'utf8')
+  const cd = await readFile(path.join(root, '.github/workflows/cd-test.yml'), 'utf8')
   const verify = cd.match(/^ {2}verify:\n([\s\S]*?)^ {2}release:\n/m)?.[1] ?? ''
   const release = cd.match(/^ {2}release:\n([\s\S]*)/m)?.[1] ?? ''
 


### PR DESCRIPTION
Cierra la causa del incidente del 18 de agosto de 2026.

## Qué pasaba

Los dos stacks de Portainer seguían la **misma** referencia y se distinguían sólo por el `Compose path` — está así en `infra/README.md`:

| Campo | Valor |
|---|---|
| Reference | `refs/heads/main` |
| Compose path | `infra/prod/compose.yml` **o** `infra/test/compose.yml` |

Con ese montaje no hay frontera entre probar y publicar: cualquier commit en `main` llega a los dos entornos a la vez.

El 18 de agosto una rama de features traía, junto a su trabajo, el `infra/prod/compose.yml` endurecido de la revisión de seguridad. Al mergear, Portainer lo recogió e intentó redesplegar producción con un Compose que exigía `DB_APP_PASSWORD` y `DB_WORKER_PASSWORD`, que no estaban en su `.env`. Falló al interpolar, **antes de tocar ningún contenedor**, así que el servicio siguió en pie — pero ese margen lo puso el azar, no el diseño. La «Transición obligatoria desde `v1.0.5`» son nueve pasos con copia de seguridad y reinserción por Deep Linking: justo lo que no puede disparar un merge.

## Qué cambia

**El entorno es la rama.**

```text
feature/* ── PR ──▶ CI ──▶ merge a test
                              │
                              ├─ cd-test.yml: verifica y construye UNA vez
                              ├─ publica app/worker/proxy:sha-<commit>
                              ├─ actualiza infra/test/compose.yml EN `test`
                              └─ Portainer (refs/heads/test) despliega TEST

test ── tag vX.Y.Z ──▶ cd-promote.yml
                       ├─ re-etiqueta el MISMO digest como :vX.Y.Z
                       ├─ avanza `main` HASTA el commit etiquetado
                       ├─ actualiza infra/prod/compose.yml EN `main`
                       └─ Portainer (refs/heads/main) despliega PROD
```

- `cd-main.yml` → **`cd-test.yml`**, disparado por push a `test`, y escribe en la propia rama `test`.
- `cd-promote.yml` ahora **avanza `main` hasta el commit etiquetado** antes de escribir la etiqueta. Producción corre el mismo árbol *y* el mismo digest que se ensayaron en test, no el Compose de una rama con el código de otra. Lleva `fetch-depth: 0` porque necesita base de merge, y usa el commit resuelto por `git rev-parse` en vez de `github.sha`, que con tags anotados apunta al objeto tag.
- Dependabot apunta a `test`.

Sigue siendo *build once, promote up*: promocionar **no reconstruye nada**.

## Los dos cierres

Una convención que sólo vive en la cabeza de alguien no es un control:

- **`frontera-entornos`** en `ci.yml`: rechaza toda PR hacia `test` que toque `infra/prod/`. Producción no se edita trabajando.
- **`cd-promote` falla en cerrado** si el commit etiquetado no tiene su imagen `sha-*` publicada — es decir, si no ha pasado por test.

## Organización

Se mantiene `infra/{test,prod}/`, como pediste. La alternativa (un Compose único parametrizado por `.env`) elimina la divergencia por construcción pero pierde la separación visible; con la frontera puesta en la rama, la divergencia deja de ser el riesgo que era. Queda razonado en el ADR-028.

## Después de mergear — hay dos pasos manuales

1. Crear la rama: `git checkout main && git pull && git checkout -b test && git push -u origin test`
2. En Portainer, stack de **test**: `Reference` → `refs/heads/test`. El de prod se queda en `refs/heads/main`.

Hasta que hagas el paso 2, test seguirá leyendo `main` y dejará de recibir despliegues (ya no hay CD sobre `main`).

## Nota de numeración

El ADR nuevo es el **028**. Tienes un **ADR-027** sin commitear en tu árbol de trabajo, así que he dejado el hueco libre en vez de pisártelo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)