### PR TITLE
ci: release.yml vuelve a ser sólo el tag, y una guía para probar el p…

### DIFF
--- a/.github/DESPLIEGUE.md
+++ b/.github/DESPLIEGUE.md
@@ -1,0 +1,266 @@
+# Despliegue: cómo sube un cambio, y cómo probarlo
+
+> Este fichero se llama `DESPLIEGUE.md` y no `README.md` a propósito. GitHub usa
+> `.github/README.md` como **portada del repositorio**, por delante de la raíz:
+> crearlo aquí sustituiría el `README.md` público del proyecto por este manual
+> interno. El orden que aplica GitHub es `.github/README.md` → `README.md` →
+> `docs/README.md`.
+
+Dos reglas sostienen todo lo demás. Si sólo lees dos frases, que sean estas:
+
+1. **El entorno es la rama** ([ADR-028](../docs/decisiones.md)). `test` es el
+   entorno de pruebas y `main` **es producción**. A `main` no se mergea: sólo la
+   mueve la promoción.
+2. **Build once, promote up.** La imagen se construye **una vez**, al entrar en
+   `test`. Promocionar a producción **no reconstruye nada**: re-etiqueta el mismo
+   digest. Producción corre el binario que se ensayó, no uno equivalente.
+
+---
+
+## Los cinco workflows
+
+| Fichero | Se dispara con | Qué hace | Publica imagen |
+|---|---|---|---|
+| `ci.yml` | PR (cualquier base) | Frontera entre entornos, lint, tests, validación de Compose | No |
+| `cd-test.yml` | push a `test`, o a mano | Verifica → construye → publica `sha-*` → despliega test | **Sí** |
+| `cd-promote.yml` | tag `v*` | Re-etiqueta el digest, avanza `main`, despliega prod | No (re-etiqueta) |
+| `release.yml` | a mano | Calcula la versión y crea el tag. Nada más | No |
+| `codeql.yml` | PR a `main` + lunes | Análisis estático | No |
+
+`ci.yml` y `cd-test.yml` duplican la verificación a propósito: así cada commit
+se construye **una vez**, no dos. `ci.yml` corre sólo en PR; los pushes a `test`
+los cubre `cd-test.yml`, que ya verifica antes de publicar.
+
+---
+
+## El recorrido de un cambio
+
+```
+  rama de trabajo
+        │
+        │  PR  ──────────────► ci.yml
+        │                      ├─ frontera-entornos  (¿toca infra/prod/? → ✖)
+        │                      ├─ lint · npm test · integración con Postgres
+        │                      └─ docker compose config de test, prod y local
+        ▼
+      test ─────────────────► cd-test.yml
+                               ├─ verify: audit, lint, tests, PDF con qpdf/gs,
+                               │          migraciones x2 + integración
+                               ├─ bake x1 → app + worker + proxy
+                               │            amd64 + arm64, SBOM + provenance
+                               ├─ push  ghcr…/app:sha-a1b2c3d  +  :edge
+                               ├─ cosign sign (keyless OIDC)
+                               ├─ trivy HIGH/CRITICAL → exit 1 si hay
+                               ├─ sed en infra/test/compose.yml DE LA RAMA test
+                               └─ commit "deploy(test): sha-a1b2c3d [skip ci]"
+                                          │
+                                          └─► Portainer test (refs/heads/test)
+
+  release.yml (a mano) ─── crea el tag vX.Y.Z sobre el commit de test
+                                          │
+                                          ▼
+                                    cd-promote.yml
+                               ├─ cosign verify (identidad = cd-test.yml@test)
+                               ├─ imagetools create :sha-a1b2c3d → :vX.Y.Z + :latest
+                               │        ▲ mismo manifiesto, MISMO DIGEST, ~40 s
+                               ├─ merge --no-ff de ese commit en main
+                               ├─ sed en infra/prod/compose.yml → :vX.Y.Z
+                               └─ commit "deploy(prod): vX.Y.Z [skip ci]"
+                                          │
+                                          └─► Portainer prod (refs/heads/main)
+```
+
+**Dónde está exactamente la reutilización.** `docker buildx imagetools create`
+opera sobre el **manifiesto**, no sobre las capas: no descarga la imagen, no
+resuelve `npm ci`, no vuelve a compilar nada. `:v1.0.6` y `:sha-a1b2c3d` acaban
+siendo dos etiquetas del **mismo objeto** en GHCR. Se comprueba, y más abajo hay
+un comando para hacerlo.
+
+---
+
+## Prerrequisitos (una vez)
+
+### En el repositorio
+
+Nada obligatorio: `GITHUB_TOKEN` basta para publicar en GHCR y para firmar con
+cosign en modo keyless. Dos secretos **opcionales**:
+
+| Secreto | Para qué | Si falta |
+|---|---|---|
+| `PORTAINER_WEBHOOK_TEST` | Avisar a Portainer al desplegar test | Redespliega en su siguiente polling |
+| `PORTAINER_WEBHOOK_PROD` | Lo mismo para producción | Igual |
+
+### En Portainer — **el campo que separa producción de pruebas**
+
+| Campo | Producción | Pruebas |
+|---|---|---|
+| Reference | `refs/heads/main` | **`refs/heads/test`** |
+| Compose path | `infra/prod/compose.yml` | `infra/test/compose.yml` |
+| GitOps updates | Activado | Activado |
+
+> Si los dos stacks siguen la misma referencia, no hay frontera: cualquier commit
+> los mueve a la vez. Es lo que pasó el 18 de agosto de 2026 y de ahí sale
+> ADR-028. **Compruébalo antes de nada.**
+
+### En el `.env` de los dos stacks
+
+Dos variables nuevas frente a `v1.0.5`, y **el stack no arranca sin ellas**
+(`${DB_APP_PASSWORD:?falta DB_APP_PASSWORD}`):
+
+```
+DB_APP_PASSWORD=<openssl rand -hex 32>
+DB_WORKER_PASSWORD=<openssl rand -hex 32>
+```
+
+Son secretos **nuevos**, no rotaciones: se generan libremente. `DB_PASSWORD` —la
+del propietario— **no se toca**, tiene que seguir cuadrando con lo persistido en
+`pgdata`. Los roles `moodleshield_app` y `moodleshield_worker` los crea solo el
+contenedor de migración: `DB_PROVISION_SERVICE_ROLES` está fijado a `"true"`
+dentro del Compose y no se puede cambiar desde el `.env`.
+
+---
+
+## Ensayo de punta a punta
+
+### 1 · Que `test` exista y Portainer la siga
+
+```bash
+git ls-remote --heads origin test
+```
+
+Si no sale nada, créala desde `main` —nacen idénticas— y repunta el stack de test
+a `refs/heads/test` en Portainer.
+
+### 2 · Primer build
+
+`cd-test.yml` ignora `docs/**` y `**/*.md`, así que **una PR que sólo toca
+documentación no construye nada**. Para el primer arranque, o cuando quieras
+forzarlo, lánzalo a mano:
+
+*Actions → «CD · test: publicar imágenes y desplegar en test» → Run workflow → test*
+
+Qué mirar, en orden:
+
+| Paso | Qué demuestra |
+|---|---|
+| `Dependencias sin vulnerabilidades conocidas` | `npm audit --audit-level=low` |
+| `Lint y tests` | 356 unitarias |
+| `Pruebas PDF y trazador…` | Las 8 pruebas que necesitan `qpdf`/`pdfinfo`/`gs` |
+| `Verificar migraciones contra Postgres real` | Migra **dos veces** (reejecutable) + integración |
+| `Validar compose e higiene de secretos` | Ningún `.env.sample` con secreto relleno |
+| `Bake y push` | Tres imágenes, dos arquitecturas, **una sola invocación** |
+| `Firmar los tres manifiestos` | cosign keyless |
+| `CVE altas/críticas` x3 | Trivy corta el despliegue si hay HIGH/CRITICAL |
+| `Desplegar en test` | Commit `deploy(test): sha-… [skip ci]` **en la rama `test`** |
+
+### 3 · Que test corre lo que crees
+
+```bash
+git fetch origin test
+git show origin/test:infra/test/compose.yml | grep 'image: ghcr'
+curl -fsS https://<tu-test>/healthz
+curl -fsS https://<tu-test>/readyz
+```
+
+Las tres etiquetas tienen que ser el mismo `sha-<7>`, y coincidir con el commit
+padre del `deploy(test)`.
+
+### 4 · Promocionar
+
+*Actions → «Release · promoción manual de test a producción» → Run workflow →
+elegir el salto*
+
+El número no se teclea: sale del último tag `vX.Y.Z`. El workflow crea el tag
+sobre el commit **de `test`** y ahí termina su trabajo; el tag dispara
+`cd-promote.yml`, que hace la promoción de verdad.
+
+También vale a mano, si prefieres elegir el commit:
+
+```bash
+git tag v1.0.6 <sha-del-commit-de-test> && git push origin v1.0.6
+```
+
+### 5 · La prueba de que es la misma imagen
+
+Esto es lo único que demuestra *build once, promote up*. Los dos digests tienen
+que ser **idénticos**:
+
+```bash
+docker buildx imagetools inspect ghcr.io/jamataran/moodleshield/app:sha-a1b2c3d \
+  --format '{{.Manifest.Digest}}'
+docker buildx imagetools inspect ghcr.io/jamataran/moodleshield/app:v1.0.6 \
+  --format '{{.Manifest.Digest}}'
+```
+
+Y que la firma es la del pipeline, no la de cualquiera:
+
+```bash
+cosign verify \
+  --certificate-identity "https://github.com/jamataran/moodleshield/.github/workflows/cd-test.yml@refs/heads/test" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/jamataran/moodleshield/app:v1.0.6
+```
+
+### 6 · Que producción se movió entera
+
+```bash
+git fetch origin main
+git log --oneline -3 origin/main          # merge del commit de test + deploy(prod)
+git show origin/main:infra/prod/compose.yml | grep 'image: ghcr'
+```
+
+`main` tiene que contener el commit ensayado, no sólo la etiqueta nueva.
+
+---
+
+## Las cuatro cosas que **deben** fallar
+
+Un control que nunca has visto fallar no sabes si existe. Estas son pruebas
+negativas: si alguna pasa, el pipeline está roto.
+
+**a) Una PR hacia `test` que toque `infra/prod/`.** El job `frontera-entornos`
+la rechaza. Producción no se edita trabajando.
+
+**b) Un tag sobre un commit que no pasó por `test`.** `cd-promote` comprueba que
+existe `:sha-<commit>` en GHCR y falla en cerrado:
+
+> No existe ghcr.io/…/app:sha-xxxxxxx. Sólo se etiquetan commits que hayan pasado
+> por `test`.
+
+**c) Un `.env.sample` con un secreto relleno.** El paso de higiene recorre
+`infra/*/.env.sample` y falla si una clave `*SECRET*`, `*PASSWORD*`, `*TOKEN*` o
+`*AUTHKEY*` trae valor.
+
+**d) Una imagen con un CVE HIGH o CRITICAL.** Trivy sale con código 1 y el
+despliegue no llega a escribir el Compose.
+
+---
+
+## Errores que verás y qué significan
+
+| Mensaje | Qué pasa | Qué hacer |
+|---|---|---|
+| `falta DB_APP_PASSWORD` al interpolar | El `.env` del stack no tiene los secretos nuevos | Añadirlos; ver arriba |
+| `No existe ghcr.io/…:sha-…` | Se etiquetó algo que no pasó por `test` | Empujar a `test`, esperar el build, etiquetar ese commit |
+| `Esta PR cambia infra/prod/` | La PR toca producción | Sacar el cambio; va en la promoción |
+| `test se movió durante el push` | Otro push aterrizó mientras se construía | Se reintenta 3 veces solo |
+| `repository does not contain ref` en bake | Contexto git remoto borrado | Ya cubierto con `source: .` |
+| El workflow no arranca al empujar | El cambio sólo toca `docs/**` o `*.md` | Lanzarlo con *Run workflow* |
+
+---
+
+## Reversión
+
+Devolver los dos stacks de Portainer a `refs/heads/main`, cambiar el disparador
+de `cd-test.yml` a `branches: [main]` y quitar el job `frontera-entornos`. La
+rama `test` puede quedarse: no la lee nadie más. **Conviene no hacerlo**: es
+volver a la situación que causó el incidente.
+
+---
+
+## Referencias
+
+- [ADR-028](../docs/decisiones.md) — el entorno es la rama
+- [`infra/README.md`](../infra/README.md) — alta de los stacks en Portainer
+- [`docs/desarrollo.md`](../docs/desarrollo.md) — flujo de Git y convenciones
+- [`docs/revision-seguridad-2026-08-10.md`](../docs/revision-seguridad-2026-08-10.md) — transición desde `v1.0.5`

--- a/.github/workflows/cd-promote.yml
+++ b/.github/workflows/cd-promote.yml
@@ -56,6 +56,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Instalar cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      # Se promociona un digest sin reconstruirlo, así que lo único que
+      # demuestra su procedencia es la firma que le puso `cd-test.yml` al
+      # publicarlo. Verificarla aquí es lo que impide promocionar una imagen
+      # empujada a GHCR por cualquier otro camino.
+      - name: Verificar la firma de las imágenes ensayadas en test
+        env:
+          REPO: ${{ steps.meta.outputs.repo }}
+          SRC: ${{ steps.meta.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/cd-test.yml@refs/heads/test"
+          for img in app worker proxy; do
+            cosign verify \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "ghcr.io/${REPO}/${img}:${SRC}" >/dev/null
+            echo "✓ firma verificada: ${img}:${SRC}"
+          done
+
       - name: Re-etiquetar el mismo digest (app + worker + proxy)
         env:
           REPO: ${{ steps.meta.outputs.repo }}
@@ -102,6 +124,12 @@ jobs:
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/app:.*$|    image: ghcr.io/jamataran/moodleshield/app:${VERSION}|"       infra/prod/compose.yml
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/worker:.*$|    image: ghcr.io/jamataran/moodleshield/worker:${VERSION}|" infra/prod/compose.yml
             sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/proxy:.*$|    image: ghcr.io/jamataran/moodleshield/proxy:${VERSION}|"   infra/prod/compose.yml
+            # Activación atómica del entorno reducido del worker, en el MISMO
+            # commit que la imagen: nunca se aplica a una imagen antigua cuyo
+            # config.js todavía exige los secretos web. Vivía en release.yml
+            # cuando ese workflow escribía el Compose de producción; al pasar la
+            # promoción aquí (ADR-028) tenía que venirse con ella.
+            sed -i "s|environment: \*app-env # WORKER_ENV_ACTIVATION|environment: *worker-env # WORKER_ENV_ACTIVATION|" infra/prod/compose.yml
 
             # El commit del bump es condicional; el push NO, porque el merge de
             # arriba también tiene que llegar a main aunque la etiqueta ya fuera

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,15 @@
-name: 'Release · promoción manual de test a producción'
+name: 'Release · crear el tag de promoción sobre test'
 
-# Publicación manual desde GitHub Actions. Evita tener que localizar a mano el
-# commit padre de deploy(test): crea el tag y promueve el mismo digest.
+# Este workflow SÓLO crea el tag. La promoción la hace `cd-promote.yml`, que se
+# dispara con `v*`: re-etiqueta el digest ensayado, avanza `main` hasta el commit
+# y escribe `infra/prod/compose.yml`. Aquí no se toca GHCR ni `main`.
+#
+# Antes de ADR-028 este fichero hacía las dos cosas, y quedó desincronizado al
+# separar los entornos por rama: leía `infra/test/compose.yml` desde `main`
+# —donde ya nunca se actualiza, porque el bump `deploy(test)` aterriza en
+# `test`—, buscaba el commit en `origin/main` y verificaba una firma emitida por
+# `cd-main.yml@refs/heads/main`, workflow que ya no existe. Habría promocionado
+# una imagen congelada, o no habría promocionado nada.
 #
 # La versión no se teclea: se elige el tipo de salto y el job la deriva del
 # último tag vX.Y.Z. El desplegable de GitHub sólo admite literales fijos, así
@@ -25,21 +33,22 @@ concurrency:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
-  release:
-    name: Etiquetar y publicar en producción
+  tag:
+    name: Etiquetar el commit ensayado en test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Obtener main completo
+      # `test` es la única fuente: es donde `cd-test.yml` escribe el bump y, por
+      # tanto, lo único que dice qué imagen se ha ensayado de verdad.
+      - name: Obtener test completo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: test
           fetch-depth: 0
 
-      - name: Resolver y validar versión e imagen de test
+      - name: Resolver versión y commit de test
         id: meta
         env:
           BUMP: ${{ inputs.bump }}
@@ -85,7 +94,7 @@ jobs:
           app_image=$(awk '$1 == "image:" && $2 ~ /\/app:/ {print $2; exit}' infra/test/compose.yml)
           sha_tag="${app_image##*:}"
           [[ "$sha_tag" =~ ^sha-[0-9a-f]{7,40}$ ]] || {
-            echo "::error::infra/test/compose.yml no apunta a una imagen sha-* válida: $sha_tag"
+            echo "::error::infra/test/compose.yml no apunta a una imagen sha-* válida: $sha_tag. ¿Ha corrido ya cd-test.yml sobre esta rama?"
             exit 1
           }
 
@@ -95,20 +104,22 @@ jobs:
           # Sólo se nota cuando la salida pasa de 4 KB (el buffer de stdio),
           # así que funcionó hasta que la historia creció lo suficiente.
           deploy_commit=$(git log -n 1 --format='%H' --fixed-strings \
-            --grep="deploy(test): ${sha_tag} [skip ci]" origin/main)
+            --grep="deploy(test): ${sha_tag} [skip ci]" origin/test)
           [[ -n "$deploy_commit" ]] || {
-            echo "::error::No se encontró el commit deploy(test) de $sha_tag en main"
+            echo "::error::No se encontró el commit deploy(test) de $sha_tag en la rama test"
             exit 1
           }
 
+          # El commit que se etiqueta es el PADRE del bump: el que se construyó y
+          # se ensayó. El bump sólo cambia la etiqueta de imagen del Compose.
           source_commit=$(git rev-parse "${deploy_commit}^")
           source_tag="sha-${source_commit:0:7}"
           [[ "$source_tag" == "$sha_tag" ]] || {
             echo "::error::$sha_tag no corresponde al commit padre de $deploy_commit"
             exit 1
           }
-          git merge-base --is-ancestor "$source_commit" origin/main || {
-            echo "::error::El commit de test no pertenece a main"
+          git merge-base --is-ancestor "$source_commit" origin/test || {
+            echo "::error::El commit $source_commit no pertenece a test"
             exit 1
           }
 
@@ -118,16 +129,15 @@ jobs:
               echo "::error::El tag $VERSION ya existe y apunta a otro commit"
               exit 1
             }
-            echo "El tag $VERSION ya apunta al commit correcto; continuamos la promoción"
+            echo "El tag $VERSION ya apunta al commit correcto"
           fi
 
-          echo "repo=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-          echo "sha_tag=$sha_tag" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=$sha_tag"             >> "$GITHUB_OUTPUT"
           echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION"             >> "$GITHUB_OUTPUT"
+          echo "previous=$previous"           >> "$GITHUB_OUTPUT"
 
-      - name: Crear tag de release
+      - name: Crear y empujar el tag
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
@@ -135,91 +145,31 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if ! git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
-            git tag "$VERSION" "$SOURCE_COMMIT"
-            git push origin "$VERSION"
-          fi
-
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Instalar cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
-
-      - name: Verificar firma de las imágenes ensayadas en test
-        env:
-          REPO: ${{ steps.meta.outputs.repo }}
-          SOURCE_TAG: ${{ steps.meta.outputs.sha_tag }}
-        run: |
-          set -euo pipefail
-          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/cd-main.yml@refs/heads/main"
-          for image in app worker proxy; do
-            cosign verify \
-              --certificate-identity "$identity" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-              "ghcr.io/${REPO}/${image}:${SOURCE_TAG}" >/dev/null
-          done
-
-      - name: Promover el mismo digest a GHCR
-        env:
-          REPO: ${{ steps.meta.outputs.repo }}
-          SOURCE_TAG: ${{ steps.meta.outputs.sha_tag }}
-          VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          set -euo pipefail
-          for image in app worker proxy; do
-            source="ghcr.io/${REPO}/${image}:${SOURCE_TAG}"
-            docker buildx imagetools inspect "$source" >/dev/null
-            docker buildx imagetools create \
-              -t "ghcr.io/${REPO}/${image}:${VERSION}" \
-              -t "ghcr.io/${REPO}/${image}:latest" \
-              "$source"
-          done
-
-      - name: Apuntar producción a la nueva versión
-        env:
-          VERSION: ${{ steps.meta.outputs.version }}
-          REPO: ${{ steps.meta.outputs.repo }}
-        run: |
-          set -euo pipefail
-          git fetch origin main
-          git checkout -B main origin/main
-          sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/app:.*$|    image: ghcr.io/jamataran/moodleshield/app:${VERSION}|"       infra/prod/compose.yml
-          sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/worker:.*$|    image: ghcr.io/jamataran/moodleshield/worker:${VERSION}|" infra/prod/compose.yml
-          sed -i -E "s|^    image: ghcr.io/jamataran/moodleshield/proxy:.*$|    image: ghcr.io/jamataran/moodleshield/proxy:${VERSION}|"   infra/prod/compose.yml
-          # Activación atómica con la primera imagen que entiende SERVICE_ROLE.
-          sed -i "s|environment: \*app-env # WORKER_ENV_ACTIVATION|environment: *worker-env # WORKER_ENV_ACTIVATION|" infra/prod/compose.yml
-          git add infra/prod/compose.yml
-          git commit -m "deploy(prod): ${VERSION} [skip ci]"
-          git push origin main
-
-      - name: Avisar a Portainer (opcional)
-        env:
-          WEBHOOK: ${{ secrets.PORTAINER_WEBHOOK_PROD }}
-        run: |
-          if [ -z "${WEBHOOK:-}" ]; then
-            echo "Sin webhook: Portainer redesplegará en su próximo polling."
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "El tag $VERSION ya está en origin; cd-promote.yml ya se disparó con él."
             exit 0
           fi
-          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$WEBHOOK")
-          echo "Portainer respondió $code"
-          [ "$code" -lt 400 ]
+          git tag "$VERSION" "$SOURCE_COMMIT"
+          # Empujar el tag dispara cd-promote.yml, que hace la promoción real.
+          git push origin "$VERSION"
 
       - name: Resumen
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           PREVIOUS: ${{ steps.meta.outputs.previous }}
-          BUMP: ${{ inputs.bump }}
-          SOURCE_TAG: ${{ steps.meta.outputs.sha_tag }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+          SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
         run: |
           {
-            echo "### Producción → \`${VERSION}\`"
+            echo "### Tag \`${VERSION}\` creado"
             echo ""
-            echo "Salto desde \`${PREVIOUS}\` (${BUMP})."
-            echo "Promocionado desde \`${SOURCE_TAG}\` sin reconstruir."
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Anterior | \`${PREVIOUS}\` |"
+            echo "| Commit de test | \`${SOURCE_COMMIT}\` |"
+            echo "| Imagen ensayada | \`${SHA_TAG}\` |"
+            echo ""
+            echo "La promoción la ejecuta **cd-promote.yml**, disparado por este tag:"
+            echo "re-etiqueta \`${SHA_TAG}\` como \`${VERSION}\` (mismo digest), avanza"
+            echo "\`main\` hasta el commit y escribe \`infra/prod/compose.yml\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | [`moodle-setup.md`](moodle-setup.md) | Alta de la herramienta en Moodle en seis pasos, con tabla de diagnóstico |
 | [`https-tunel.md`](https-tunel.md) | HTTPS público y túneles (Cloudflare, Tailscale) para desarrollo local |
 | [`../infra/README.md`](../infra/README.md) | Los tres entornos y el flujo *build once, promote up* |
+| [`../.github/DESPLIEGUE.md`](../.github/DESPLIEGUE.md) | **Manual del pipeline**: qué hace cada workflow, cómo ensayarlo de punta a punta y cómo comprobar que producción corre el mismo digest que test |
 
 ---
 

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -441,6 +441,14 @@ Sólo se etiqueta un commit que ya esté desplegado en test: si no existe su
 `:sha-<commit>` en GHCR, `cd-promote` falla en cerrado. Y una PR hacia `test` que
 toque `infra/prod/` la rechaza el job `frontera-entornos` de `ci.yml`.
 
+El tag lo puedes crear a mano o con [`release.yml`](../.github/workflows/release.yml),
+que **sólo hace eso**: deriva la versión del último `vX.Y.Z`, localiza el commit
+ensayado en `test` y empuja el tag. La promoción entera es de `cd-promote.yml`.
+
+**El manual de pruebas del pipeline —qué mirar en cada paso, cómo comprobar que
+el digest promocionado es el mismo, y las cuatro cosas que deben fallar— está en
+[`.github/DESPLIEGUE.md`](../.github/DESPLIEGUE.md).**
+
 Los cambios que sólo tocan documentación, `LICENSE`, `.idea/` o `infra/local/` no publican
 imágenes ni despliegan.
 

--- a/test/security/contenedores.test.js
+++ b/test/security/contenedores.test.js
@@ -152,9 +152,11 @@ for (const file of DEPLOYABLES) {
     }
 
     if (blocks.worker.includes('*app-env # WORKER_ENV_ACTIVATION')) {
+      // Producción la escribe cd-promote.yml desde ADR-028; release.yml sólo
+      // crea el tag.
       const workflow = file.includes('/test/')
         ? '.github/workflows/cd-test.yml'
-        : '.github/workflows/release.yml'
+        : '.github/workflows/cd-promote.yml'
       const workflowText = await readFile(path.join(root, workflow), 'utf8')
       assert.match(workflowText,
         new RegExp(`environment: \\*worker-env # WORKER_ENV_ACTIVATION\\|" ${file.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),

--- a/test/security/supply-chain.test.js
+++ b/test/security/supply-chain.test.js
@@ -33,16 +33,45 @@ test('las imágenes base desplegables están ancladas por digest', async () => {
   }
 })
 
-test('CD publica SBOM, provenance y firma; release verifica la firma', async () => {
+test('CD publica SBOM, provenance y firma; la promoción la verifica', async () => {
   const cd = await readFile(path.join(root, '.github/workflows/cd-test.yml'), 'utf8')
-  const release = await readFile(path.join(root, '.github/workflows/release.yml'), 'utf8')
+  const promote = await readFile(path.join(root, '.github/workflows/cd-promote.yml'), 'utf8')
   assert.match(cd, /\*\.attest=type=sbom/)
   assert.match(cd, /\*\.attest=type=provenance,mode=max/)
   assert.match(cd, /cosign sign --yes/)
   assert.equal((cd.match(/aquasecurity\/trivy-action@[0-9a-f]{40}/g) ?? []).length, 3)
   assert.equal((cd.match(/severity: CRITICAL,HIGH/g) ?? []).length, 3)
   assert.equal((cd.match(/exit-code: '1'/g) ?? []).length, 3)
-  assert.match(release, /cosign verify/)
+
+  // Promocionar no reconstruye: lo único que demuestra la procedencia del
+  // digest es la firma que le puso cd-test. Se verifica ANTES de re-etiquetar.
+  assert.match(promote, /cosign verify/)
+  // Por posición del PASO, no del texto: la cabecera del workflow ya menciona
+  // `imagetools create` en un comentario y adelantaría la comparación.
+  const verifyAt = promote.search(/^ {6}- name: .*[Vv]erificar la firma/m)
+  const retagAt = promote.search(/^ {6}- name: Re-etiquetar/m)
+  assert.ok(verifyAt > -1, 'cd-promote debe tener un paso que verifique la firma')
+  assert.ok(retagAt > verifyAt, 'la verificación de firma debe ir antes del re-etiquetado')
+})
+
+// La identidad del certificado lleva dentro el nombre del workflow y la rama que
+// lo emitió. Cuando ADR-028 renombró cd-main.yml a cd-test.yml y movió el build
+// a `test`, release.yml siguió verificando contra `cd-main.yml@refs/heads/main`:
+// una identidad que ya no firma nada. Esto lo ata a lo que de verdad construye.
+test('la identidad de cosign apunta al workflow y la rama que firman', async () => {
+  const promote = await readFile(path.join(root, '.github/workflows/cd-promote.yml'), 'utf8')
+  const cd = await readFile(path.join(root, '.github/workflows/cd-test.yml'), 'utf8')
+
+  const identity = promote.match(/identity="([^"]+)"/)?.[1]
+  assert.ok(identity, 'cd-promote debe fijar la identidad del certificado')
+  const workflow = identity.match(/\.github\/workflows\/([^@]+)@refs\/heads\/(.+)$/)
+  assert.ok(workflow, `identidad con formato inesperado: ${identity}`)
+  const [, file, branch] = workflow
+
+  assert.equal(file, 'cd-test.yml', 'debe verificarse contra el workflow que firma')
+  const triggers = cd.match(/branches:\s*\[([^\]]+)\]/)?.[1] ?? ''
+  assert.ok(triggers.split(',').map((b) => b.trim()).includes(branch),
+    `cd-test.yml no se dispara en '${branch}', así que nunca firmará con esa identidad`)
 })
 
 test('el CI de PR también bloquea CVE altas/críticas en las tres imágenes', async () => {


### PR DESCRIPTION
…ipeline

`release.yml` quedó escrito para el modelo de una sola rama y ADR-028 lo dejó atrás sin que nadie lo mirara: leía `infra/test/compose.yml` desde `main` —donde ya nunca se actualiza, porque el bump `deploy(test)` aterriza en `test`—, buscaba el commit del despliegue en `origin/main` y verificaba una firma emitida por `cd-main.yml@refs/heads/main`, workflow que ya no existe. Además promocionaba por su cuenta y empujaba el tag, así que también disparaba `cd-promote.yml`: dos promociones compitiendo, y la suya congelada en `sha-acaac2b`.

Ahora hace una sola cosa: derivar la versión del último `vX.Y.Z`, localizar en `test` el commit ensayado y empujar el tag. La promoción entera es de `cd-promote.yml`, que era donde ya estaba escrita bien.

Con ella se movieron las dos cosas que sólo vivían en `release.yml`:

- La verificación de firma con cosign, ahora ANTES de re-etiquetar. Promocionar no reconstruye, así que la firma de `cd-test` es lo único que demuestra de dónde sale ese digest; sin este paso, cualquier cosa empujada a GHCR con la etiqueta correcta se promocionaba sola.
- El `sed` que activa el entorno mínimo del worker en producción, que se aplica en el mismo commit que la imagen para no dárselo a una imagen antigua.

Las pruebas atan las dos al sitio nuevo, y una comprueba que la identidad del certificado nombra un workflow que existe y una rama en la que ese workflow se dispara de verdad. Es exactamente lo que había dejado de ser cierto.

`.github/DESPLIEGUE.md` cuenta el recorrido completo: qué hace cada workflow, los prerrequisitos de Portainer y del `.env`, el ensayo paso a paso, cómo comprobar que el digest de producción es el mismo que se probó en test, y las cuatro cosas que deben fallar. No se llama `README.md` porque GitHub usa `.github/README.md` como portada del repositorio por delante de la raíz, y este es público.