### PR TITLE
diag(operación): que los rechazos digan por qué, y el generador marque qué copiar

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -214,13 +214,18 @@ No regeneres el bloque al actualizar un stack. Conserva siempre sus variables.
 
 ### 3. Elegir cómo llega el nginx externo
 
+- **Nginx/Nginx Proxy Manager en otro contenedor** —el caso normal, y el valor
+  que genera el script: `HTTP_BIND_ADDRESS=0.0.0.0`. Desde dentro de ese
+  contenedor, `127.0.0.1` es su propio loopback y el upstream nunca llega. Si
+  prefieres acotar, liga la IP LAN concreta del host y úsala como upstream. Con
+  `0.0.0.0` el puerto queda en todas las interfaces: restringe quién llega a él
+  en `DOCKER-USER`, firewall o security group, porque es HTTP sin cifrar.
 - Nginx nativo en el mismo host: `HTTP_BIND_ADDRESS=127.0.0.1`.
-- Nginx/Nginx Proxy Manager en otro contenedor: `127.0.0.1` apunta al propio
-  contenedor, no al host. Liga `HTTP_BIND_ADDRESS` a la IP LAN concreta del host
-  y úsala como upstream. Si necesitas `0.0.0.0`, restringe el puerto en
-  `DOCKER-USER`, firewall o security group.
 - Nginx en otra máquina: liga a la IP LAN del servidor Docker y permite el
   puerto sólo desde la IP del edge.
+
+El valor por defecto **del Compose** sigue siendo `127.0.0.1`: un stack ya
+desplegado que no declare la variable no cambia de comportamiento al actualizar.
 
 El generador acepta `--bind-address IP`. En test, PostgreSQL usa una
 variable separada, `DB_BIND_ADDRESS=127.0.0.1`, para no publicarlo por accidente.

--- a/infra/test/.env.sample
+++ b/infra/test/.env.sample
@@ -9,7 +9,10 @@
 
 DATA_ROOT=/docker-apps/moodleshield-test
 PUBLIC_URL=https://moodleshield-test.example.com
-HTTP_BIND_ADDRESS=127.0.0.1
+# 0.0.0.0 si el nginx del edge corre EN CONTENEDOR (el caso normal): desde ahí,
+# 127.0.0.1 es su propio loopback. Con nginx nativo en el host, 127.0.0.1.
+# En ambos casos el puerto va sin cifrar: filtra quién llega a él.
+HTTP_BIND_ADDRESS=0.0.0.0
 HTTP_PORT=43128
 DB_BIND_ADDRESS=127.0.0.1
 DB_PORT_HOST=55432

--- a/infra/test/README.md
+++ b/infra/test/README.md
@@ -47,10 +47,10 @@ server {
 
 Casos de red:
 
+- nginx/Nginx Proxy Manager en un contenedor —el caso normal—:
+  `HTTP_BIND_ADDRESS=0.0.0.0`, con el puerto filtrado; o, si prefieres acotar, la
+  IP LAN concreta del host, usando `IP-PRIVADA-DEL-HOST:43128` como upstream;
 - nginx nativo en el host: `HTTP_BIND_ADDRESS=127.0.0.1`;
-- nginx/Nginx Proxy Manager en un contenedor: liga `HTTP_BIND_ADDRESS` a la IP
-  LAN concreta del host y usa `IP-PRIVADA-DEL-HOST:43128` como upstream; usa
-  `0.0.0.0` sólo con firewall;
 - no cambies `DB_BIND_ADDRESS=127.0.0.1`: publicar el HTTP no debe exponer
   PostgreSQL.
 

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -7,10 +7,15 @@
 #   ./scripts/generate-env.sh prod --public-url https://video.midominio.com \
 #                                  --admin-user profesor --bind-address 192.168.1.20
 #
-# Sólo el bloque `CLAVE=valor` sale por stdout; los avisos y las preguntas van
-# por stderr. Así, redirigir la salida da un fichero limpio y el copiar-pegar no
-# arrastra comentarios: Portainer los interpretaría como variables con nombres
-# absurdos.
+# Sólo el bloque `CLAVE=valor` sale por stdout; los avisos, las preguntas y los
+# delimitadores de «copia desde aquí» van por stderr. Así, redirigir la salida a
+# un fichero lo deja limpio, y quien copia y pega en Portainer ve exactamente
+# dónde empieza y dónde acaba lo que tiene que llevarse.
+#
+# En el bloque no va NI UNA línea de comentario: Portainer no interpreta un
+# fichero .env, mantiene una lista de pares, y un `# nota` acaba convertido en
+# una variable con nombre absurdo. Lo que haya que explicar se explica por
+# stderr, fuera de los delimitadores.
 #
 # ⚠️ WATERMARK_SECRET es permanente. Este script genera secretos NUEVOS cada
 # vez: ejecutarlo otra vez contra un stack que ya rodó y pegar el resultado
@@ -24,7 +29,11 @@ ENVIRONMENT=prod
 PUBLIC_URL=""
 ADMIN_USER=""
 DATA_ROOT=""
-HTTP_BIND_ADDRESS="127.0.0.1"
+# 0.0.0.0 porque el caso normal es un nginx/Nginx Proxy Manager EN CONTENEDOR:
+# desde ahí, 127.0.0.1 es el loopback del propio contenedor y el upstream nunca
+# llega. Con nginx nativo en el host, o para ligarlo a una IP concreta de la LAN,
+# está --bind-address.
+HTTP_BIND_ADDRESS="0.0.0.0"
 PEDIR_HASH=1
 
 uso () {
@@ -34,7 +43,8 @@ Uso: ./scripts/generate-env.sh [prod|test] [opciones]
   --public-url URL   URL pública del stack (la que verá Moodle)
   --admin-user NOMBRE  usuario de la consola de administración
   --data-root RUTA   raíz absoluta de todos los datos persistentes
-  --bind-address IP  IP donde publicar HTTP (por defecto 127.0.0.1)
+  --bind-address IP  IP donde publicar HTTP (por defecto 0.0.0.0; 127.0.0.1 con
+                     nginx nativo en el host)
   --sin-admin        no pedir contraseña: deja ADMIN_PASSWORD_HASH vacío
   -h, --help         esta ayuda
 EOF
@@ -132,9 +142,10 @@ fi
 
 gen () { openssl rand -hex 32; }
 
-cat <<EOF
+BLOQUE=$(cat <<EOF
 DATA_ROOT=$DATA_ROOT
 PUBLIC_URL=$PUBLIC_URL
+PUBLIC_URL_ALIASES=
 HTTP_BIND_ADDRESS=$HTTP_BIND_ADDRESS
 HTTP_PORT=$HTTP_PORT
 DB_NAME=moodleshield
@@ -148,8 +159,6 @@ SESSION_SECRET=$(gen)
 WATERMARK_SECRET=$(gen)
 MEDIA_KEY_SECRET=$(gen)
 MEDIA_LINK_SECRET=$(gen)
-# Deshabilitada por defecto; actívala sólo durante una migración y limita las
-# plataformas con CONTENT_API_ALLOWED_PLATFORM_IDS.
 CONTENT_API_TOKEN=
 CONTENT_API_ALLOWED_PLATFORM_IDS=
 ADMIN_USERNAME=$ADMIN_USER
@@ -166,12 +175,61 @@ MAX_UPLOAD_BYTES=$MAX_UPLOAD_BYTES
 UPLOAD_CHUNK_BYTES=16777216
 UPLOAD_SESSION_TTL_SECONDS=86400
 EOF
-[ "$ENVIRONMENT" = test ] && printf '%s\n' "DB_BIND_ADDRESS=127.0.0.1" "DB_PORT_HOST=55432"
+)
+
+# La base de test se publica en el host para poder diagnosticar; la de
+# producción no se publica en absoluto.
+if [ "$ENVIRONMENT" = test ]; then
+  BLOQUE="$BLOQUE
+DB_BIND_ADDRESS=127.0.0.1
+DB_PORT_HOST=55432"
+fi
+
+# Los delimitadores son para el ojo humano y van por stderr: con la salida
+# redirigida a un fichero el fichero queda con el bloque y nada más.
+if [ -t 1 ]; then
+  cat >&2 <<'EOF'
+
+╭──────────────────── COPIA DESDE LA LÍNEA SIGUIENTE ────────────────────╮
+EOF
+fi
+printf '%s\n' "$BLOQUE"
+if [ -t 1 ]; then
+  cat >&2 <<'EOF'
+╰──────────────────── HASTA LA LÍNEA ANTERIOR ───────────────────────────╯
+EOF
+fi
 
 cat >&2 <<EOF
 
-────────────────────────────────────────────────────────────────────────────
-Pega ese bloque en Portainer → Stack → Environment variables → Advanced mode.
+Pega ese bloque —y sólo ese bloque— en
+Portainer → Stack → Environment variables → Advanced mode.
+
+Algunos valores salen vacíos a propósito, porque este script no puede
+adivinarlos:
+
+  PUBLIC_URL_ALIASES   otros nombres por los que se alcanza ESTA instancia,
+                       separados por comas (https:// en producción). Si la
+                       instancia ya tenía alguno, VUELVE A PONERLO: sin él la
+                       consola responde 403 al iniciar sesión, porque el Origin
+                       del formulario no está en la lista blanca.
+  CONTENT_API_TOKEN    API de migración; se deja apagada. Actívala sólo durante
+                       una migración y acota con CONTENT_API_ALLOWED_PLATFORM_IDS.
+
+Y uno que conviene revisar:
+
+  HTTP_BIND_ADDRESS=$HTTP_BIND_ADDRESS
+$(if [ "$HTTP_BIND_ADDRESS" = "0.0.0.0" ]; then cat <<'AVISO'
+                       Publica el puerto en TODAS las interfaces del host, que
+                       es lo que necesita un nginx en contenedor. Detrás tiene
+                       que haber un cortafuegos: es HTTP sin cifrar. Con nginx
+                       nativo en el host, --bind-address 127.0.0.1.
+AVISO
+else cat <<'AVISO'
+                       Sólo esa interfaz. Si tu nginx corre EN UN CONTENEDOR,
+                       no llegará: necesita 0.0.0.0 o la IP LAN del host.
+AVISO
+fi)
 
 ⚠️  Guarda WATERMARK_SECRET en el gestor de contraseñas ANTES de desplegar.
     Es permanente: si se pierde o se cambia, ninguna filtración anterior se

--- a/src/admin/routes.js
+++ b/src/admin/routes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { rateLimit } from 'express-rate-limit'
 import config from '../config.js'
+import logger from '../logger.js'
 import { query } from '../db/index.js'
 import { renderPage } from '../ui/render.js'
 import { isAllowedOrigin } from '../security/public-origin.js'
@@ -131,8 +132,25 @@ adminRouter.post('/login', async (req, res, next) => {
   const origin = req.get('origin')
   // Antes se comparaba sólo contra PUBLIC_URL: entrar por el otro nombre de la
   // misma instancia —el túnel en desarrollo— devolvía 403 al iniciar sesión.
-  if (origin && !isAllowedOrigin(origin)) return res.sendStatus(403)
-  if (!verifyLoginCsrf(req, req.body?._csrf)) return res.sendStatus(403)
+  //
+  // Los dos rechazos se registran porque desde fuera son indistinguibles: un
+  // «Forbidden» de nueve bytes que el operador confunde sin remedio con una
+  // contraseña mal puesta —la contraseña mal puesta responde 401 con el
+  // formulario, no esto—. Al log va el origen rechazado y la lista que se
+  // esperaba, que es exactamente lo que hay que corregir en PUBLIC_URL_ALIASES.
+  if (origin && !isAllowedOrigin(origin)) {
+    logger.warn(
+      { origin, publicOrigins: config.publicOrigins, host: req.get('x-forwarded-host') || req.get('host') },
+      'Login de admin rechazado: el Origin no está en PUBLIC_URL ni en PUBLIC_URL_ALIASES'
+    )
+    return res.sendStatus(403)
+  }
+  if (!verifyLoginCsrf(req, req.body?._csrf)) {
+    logger.warn({ origin },
+      'Login de admin rechazado: el testigo CSRF no cuadra (cookie caducada, perdida o ' +
+      'ADMIN_SESSION_SECRET cambiado entre pintar el formulario y enviarlo)')
+    return res.sendStatus(403)
+  }
   try {
     const result = await loginAdmin({
       username: req.body?.username,

--- a/src/lti/platform.js
+++ b/src/lti/platform.js
@@ -2,6 +2,7 @@
 // servicio compartido por la API bearer y la consola web.
 export { getJwks, invalidateJwksCache } from './jwks-cache.js'
 export {
+  diagnosePlatformMiss,
   findPlatform,
   getPlatformById,
   listPlatforms,

--- a/src/lti/routes.js
+++ b/src/lti/routes.js
@@ -5,7 +5,7 @@ import config from '../config.js'
 import logger from '../logger.js'
 import { one } from '../db/index.js'
 import { getPublicJwks } from './keys.js'
-import { findPlatform, listPlatforms } from './platform.js'
+import { diagnosePlatformMiss, findPlatform, listPlatforms } from './platform.js'
 import { assertLaunchTargetAllowed, saveOidcState, validateLaunch, LtiError } from './validate.js'
 import { MESSAGE_TYPE } from './claims.js'
 import { issueSession, issueToken, verifySession, verifyToken } from '../session.js'
@@ -110,6 +110,17 @@ async function handleLogin (req, res, next) {
 
     const platform = await findPlatform({ issuer: params.iss, clientId: params.clientId })
     if (!platform) {
+      // El 404 hacia fuera no distingue el motivo, y así debe seguir. Pero al
+      // log va cuál de las tres causas es: issuer sin registrar, client_id
+      // distinto o plataforma deshabilitada. Sin esto, el operador sólo ve un
+      // 404 en el POST de Moodle y no tiene por dónde empezar.
+      const diagnostico = await diagnosePlatformMiss({
+        issuer: params.iss, clientId: params.clientId
+      }).catch(() => ({ reason: 'no_diagnosticado' }))
+      logger.warn(
+        { issuer: params.iss, clientId: params.clientId ?? null, ...diagnostico },
+        'Login LTI rechazado: ninguna plataforma registrada encaja'
+      )
       throw new LtiError(
         `Plataforma no registrada: ${params.iss}${params.clientId ? ` / ${params.clientId}` : ''}`,
         { status: 404, code: 'unknown_platform' }
@@ -806,7 +817,7 @@ ltiRouter.get('/config', (_req, res) => {
 
 export function ltiErrorHandler (err, req, res, next) {
   if (!(err instanceof LtiError)) return next(err)
-  logger.warn({ code: err.code, msg: err.message, path: req.path }, 'Error LTI')
+  logger.warn({ code: err.code, msg: err.message, path: req.path, detail: err.detail ?? undefined }, 'Error LTI')
   const wantsJson = req.accepts(['html', 'json']) === 'json'
   if (wantsJson) return res.status(err.status).json({ error: err.message, code: err.code })
   res

--- a/src/lti/validate.js
+++ b/src/lti/validate.js
@@ -5,11 +5,17 @@ import { getJwks, getPlatformById, rememberDeploymentId } from './platform.js'
 import { CLAIM, MESSAGE_TYPE, toLaunchContext } from './claims.js'
 
 export class LtiError extends Error {
-  constructor (message, { status = 400, code = 'lti_error' } = {}) {
+  /**
+   * `detail` no se le enseña a nadie: viaja al log del servidor. Sirve para los
+   * rechazos donde el mensaje público no puede decir contra qué se comparó —y
+   * sin eso el operador se queda con «desconocido: 6» y ningún «frente a qué».
+   */
+  constructor (message, { status = 400, code = 'lti_error', detail = null } = {}) {
     super(message)
     this.name = 'LtiError'
     this.status = status
     this.code = code
+    this.detail = detail
   }
 }
 
@@ -95,13 +101,15 @@ export function assertDeploymentAllowed (platform, deploymentId, {
   if (production && known.length !== 1) {
     throw new LtiError('El deployment_id debe registrarse antes del primer launch', {
       status: 401,
-      code: 'deployment_not_configured'
+      code: 'deployment_not_configured',
+      detail: { recibido: deploymentId, registrados: known }
     })
   }
   if (known.length > 0 && !known.includes(deploymentId)) {
     throw new LtiError(`deployment_id desconocido: ${deploymentId}`, {
       status: 401,
-      code: 'unknown_deployment_id'
+      code: 'unknown_deployment_id',
+      detail: { recibido: deploymentId, registrados: known }
     })
   }
   return { learn: !production && known.length === 0 }

--- a/src/services/platforms.js
+++ b/src/services/platforms.js
@@ -50,6 +50,38 @@ export function findPlatform ({ issuer, clientId }) {
   })
 }
 
+/**
+ * Por qué NO ha encajado una plataforma, para el log del operador.
+ *
+ * Un launch contra una plataforma que no encaja responde 404 y el mensaje no
+ * distingue el motivo: hacia fuera está bien —no confirma qué hay registrado—,
+ * pero deja al operador con tres causas indistinguibles y ninguna pista. Esto
+ * las separa **sólo para el log del servidor**, que es donde puede mirar quien
+ * administra la instancia. La respuesta HTTP no cambia.
+ */
+export async function diagnosePlatformMiss ({ issuer, clientId }) {
+  const rows = await many(
+    'SELECT client_id, enabled FROM lti_platform WHERE issuer = $1 ORDER BY created_at',
+    [issuer]
+  )
+  if (rows.length === 0) {
+    return { reason: 'issuer_no_registrado', hint: 'Ningún registro con ese issuer. Comprueba que el issuer de Moodle coincide EXACTAMENTE (sin barra final, y sólo el origen: la consola rechaza issuers con ruta).' }
+  }
+  const match = clientId ? rows.find((row) => row.client_id === clientId) : null
+  if (clientId && !match) {
+    return {
+      reason: 'client_id_distinto',
+      clientIdsRegistrados: rows.map((row) => row.client_id),
+      hint: 'El issuer sí está registrado, pero con otro client_id. En Moodle es el «ID de cliente» de la herramienta.'
+    }
+  }
+  const vivas = (match ? [match] : rows).filter((row) => row.enabled)
+  if (vivas.length === 0) {
+    return { reason: 'plataforma_deshabilitada', hint: 'La plataforma existe pero está deshabilitada: actívala en la consola.' }
+  }
+  return { reason: 'desconocido' }
+}
+
 export function getPlatformById (id) {
   return one('SELECT * FROM lti_platform WHERE id = $1', [id])
 }


### PR DESCRIPTION
Tres rechazos de PRE que estaban bien decididos y mal contados: el síntoma no
llevaba a la causa. Ninguno cambia lo que se acepta o se rechaza; cambian lo que
queda escrito cuando se rechaza.

- **Login de admin.** `Forbidden` de nueve bytes, indistinguible de una
  contraseña mal puesta —que en realidad responde 401 con el formulario—. Ahora
  el log dice cuál de los dos filtros ha sido y, en el del origen, contra qué
  lista se comparó: es lo que hay que corregir en `PUBLIC_URL_ALIASES`.
- **Login LTI.** El 404 sigue sin distinguir hacia fuera —no debe confirmar qué
  hay registrado—, pero al log va cuál de las tres causas es: issuer sin
  registrar, `client_id` distinto o plataforma deshabilitada.
- **Deployment.** «deployment_id desconocido: 6» no decía frente a qué. `LtiError`
  admite un `detail` que no se enseña a nadie y sólo viaja al log.

Y el generador de entorno, que es donde nacían dos de los problemas:

- `HTTP_BIND_ADDRESS` pasa a `0.0.0.0`: el caso normal es un nginx **en
  contenedor**, y desde ahí `127.0.0.1` es su propio loopback. El valor por
  defecto del Compose se queda en `127.0.0.1` a propósito, para que un stack ya
  desplegado que no declare la variable no cambie al actualizar.
- El bloque se ve **dónde empieza y dónde acaba** (delimitadores por stderr y
  sólo si mira una persona, así que redirigir a fichero lo sigue dejando limpio)
  y es ya sólo `CLAVE=valor`: Portainer mantiene una lista de pares, no
  interpreta un `.env`. Lo que había que explicar se explica fuera, empezando
  por `PUBLIC_URL_ALIASES` —que el script nunca ha emitido, y cuya pérdida al
  regenerar el bloque es lo que dejó la consola en 403.

Sin cambios en `infra/prod/`: van aparte, en `chore/infra-prod-pendiente-promocion`,
para la PR de promoción.

`npm run lint` limpio y `npm test` en 352 pasados, 0 fallos, 9 saltados (PDF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt