### PR TITLE
Test idéntico a producción, fps que no se desploma y qué stack es cada uno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,10 @@ VIDEO_MAX_SOURCE_FPS=120
 VIDEO_MAX_AUDIO_CHANNELS=8
 # Cota VBV por variante; permite reservar disco/cuota antes de ejecutar ffmpeg.
 VIDEO_MAX_OUTPUT_BITRATE_KBPS=8000
+# Recorta el lado largo de la salida. 0 = sin recorte (comportamiento histórico).
+# 1080 es lo sensato para un reproductor dentro de un iframe: en vídeo vertical
+# de móvil (1440x1920) divide por tres los píxeles, y se codifican DOS veces.
+VIDEO_MAX_OUTPUT_LONG_SIDE=0
 # La copia descargable se sella y cifra en memoria dentro del proceso web
 # (512 MB): por encima de este tamaño se deniega la descarga, no la lectura.
 PDF_DOWNLOAD_MAX_BYTES=52428800

--- a/infra/local/compose.yml
+++ b/infra/local/compose.yml
@@ -29,6 +29,9 @@ x-app-env: &app-env
   # development: permite PUBLIC_URL http y secretos por defecto. La mecánica
   # (firma de segmentos, cifrado, LTI) es idéntica a producción.
   NODE_ENV: development
+  # Literal, NO interpolado: es lo único que no se puede pegar mal desde otro
+  # entorno. NODE_ENV no distingue test de producción; esto sí.
+  MOODLESHIELD_ENV: local
   SERVICE_ROLE: app
   LOG_LEVEL: ${LOG_LEVEL:-debug}
   PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8088}
@@ -101,6 +104,8 @@ x-app-env: &app-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # 0 = sin recorte. 1080 recorta el lado largo y abarata mucho el vídeo vertical.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}
@@ -116,6 +121,9 @@ x-app-env: &app-env
 
 x-worker-env: &worker-env
   NODE_ENV: development
+  # Literal, NO interpolado: es lo único que no se puede pegar mal desde otro
+  # entorno. NODE_ENV no distingue test de producción; esto sí.
+  MOODLESHIELD_ENV: local
   SERVICE_ROLE: worker
   LOG_LEVEL: ${LOG_LEVEL:-debug}
   DB_HOST: db
@@ -146,6 +154,8 @@ x-worker-env: &worker-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # 0 = sin recorte. 1080 recorta el lado largo y abarata mucho el vídeo vertical.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}

--- a/infra/test/compose.yml
+++ b/infra/test/compose.yml
@@ -34,7 +34,7 @@ x-app-env: &app-env
   # entorno. NODE_ENV no distingue test de producción; esto sí.
   MOODLESHIELD_ENV: test
   SERVICE_ROLE: app
-  LOG_LEVEL: ${LOG_LEVEL:-debug}
+  LOG_LEVEL: ${LOG_LEVEL:-info}
   PUBLIC_URL: ${PUBLIC_URL:?falta PUBLIC_URL}
   DB_HOST: db
   DB_PORT: "5432"
@@ -74,24 +74,24 @@ x-app-env: &app-env
   MEDIA_DELIVERY: signed
   MEDIA_PUBLIC_PREFIX: /media
   MEDIA_LINK_TTL_SECONDS: ${MEDIA_LINK_TTL_SECONDS:-14400}
-  MAX_UPLOAD_BYTES: ${MAX_UPLOAD_BYTES:-2147483648}
+  MAX_UPLOAD_BYTES: ${MAX_UPLOAD_BYTES:-4294967296}
   UPLOAD_CHUNK_BYTES: ${UPLOAD_CHUNK_BYTES:-16777216}
   UPLOAD_SESSION_TTL_SECONDS: ${UPLOAD_SESSION_TTL_SECONDS:-86400}
-  STORAGE_MIN_FREE_BYTES: ${STORAGE_MIN_FREE_BYTES:-1073741824}
+  STORAGE_MIN_FREE_BYTES: ${STORAGE_MIN_FREE_BYTES:-5368709120}
   MAX_ACTIVE_UPLOADS_PER_OWNER: ${MAX_ACTIVE_UPLOADS_PER_OWNER:-5}
   # -1 = cola sin tope. El disco lo siguen guardando STORAGE_MIN_FREE_BYTES
   # y MAX_STORED_BYTES_PER_OWNER.
   MAX_PENDING_JOBS_PER_OWNER: ${MAX_PENDING_JOBS_PER_OWNER:--1}
-  MAX_RESERVED_UPLOAD_BYTES_PER_OWNER: ${MAX_RESERVED_UPLOAD_BYTES_PER_OWNER:-4294967296}
-  MAX_STORED_BYTES_PER_OWNER: ${MAX_STORED_BYTES_PER_OWNER:-53687091200}
+  MAX_RESERVED_UPLOAD_BYTES_PER_OWNER: ${MAX_RESERVED_UPLOAD_BYTES_PER_OWNER:-8589934592}
+  MAX_STORED_BYTES_PER_OWNER: ${MAX_STORED_BYTES_PER_OWNER:-107374182400}
   PLAYBACK_MAX_DISTINCT_IPS: ${PLAYBACK_MAX_DISTINCT_IPS:-3}
   PLAYBACK_REVOKE_ON_SUSPICION: ${PLAYBACK_REVOKE_ON_SUSPICION:-true}
   SEGMENT_SECONDS: ${SEGMENT_SECONDS:-4}
   OUTPUT_FPS: ${OUTPUT_FPS:-24}
-  OUTPUT_CRF: ${OUTPUT_CRF:-23}
+  OUTPUT_CRF: ${OUTPUT_CRF:-21}
   OUTPUT_PRESET: ${OUTPUT_PRESET:-veryfast}
   # Marca visible: en pruebas interesa verla.
-  MARK_ALPHA: ${MARK_ALPHA:-0.5}
+  MARK_ALPHA: ${MARK_ALPHA:-0.06}
   TRANSCODE_CONCURRENCY: ${TRANSCODE_CONCURRENCY:-1}
   TRANSCODE_LEASE_SECONDS: ${TRANSCODE_LEASE_SECONDS:-90}
   TRANSCODE_HEARTBEAT_MS: ${TRANSCODE_HEARTBEAT_MS:-20000}
@@ -127,7 +127,7 @@ x-worker-env: &worker-env
   # entorno. NODE_ENV no distingue test de producción; esto sí.
   MOODLESHIELD_ENV: test
   SERVICE_ROLE: worker
-  LOG_LEVEL: ${LOG_LEVEL:-debug}
+  LOG_LEVEL: ${LOG_LEVEL:-info}
   DB_HOST: db
   DB_PORT: "5432"
   DB_NAME: ${DB_NAME:-moodleshield}
@@ -138,14 +138,14 @@ x-worker-env: &worker-env
   UPLOAD_ROOT: /data/uploads
   SESSION_TTL_SECONDS: ${SESSION_TTL_SECONDS:-14400}
   MEDIA_LINK_TTL_SECONDS: ${MEDIA_LINK_TTL_SECONDS:-14400}
-  MAX_UPLOAD_BYTES: ${MAX_UPLOAD_BYTES:-2147483648}
+  MAX_UPLOAD_BYTES: ${MAX_UPLOAD_BYTES:-4294967296}
   UPLOAD_CHUNK_BYTES: ${UPLOAD_CHUNK_BYTES:-16777216}
   UPLOAD_SESSION_TTL_SECONDS: ${UPLOAD_SESSION_TTL_SECONDS:-86400}
   SEGMENT_SECONDS: ${SEGMENT_SECONDS:-4}
   OUTPUT_FPS: ${OUTPUT_FPS:-24}
-  OUTPUT_CRF: ${OUTPUT_CRF:-23}
+  OUTPUT_CRF: ${OUTPUT_CRF:-21}
   OUTPUT_PRESET: ${OUTPUT_PRESET:-veryfast}
-  MARK_ALPHA: ${MARK_ALPHA:-0.5}
+  MARK_ALPHA: ${MARK_ALPHA:-0.06}
   TRANSCODE_CONCURRENCY: ${TRANSCODE_CONCURRENCY:-1}
   TRANSCODE_LEASE_SECONDS: ${TRANSCODE_LEASE_SECONDS:-90}
   TRANSCODE_HEARTBEAT_MS: ${TRANSCODE_HEARTBEAT_MS:-20000}
@@ -177,6 +177,9 @@ services:
       POSTGRES_DB: ${DB_NAME:-moodleshield}
       POSTGRES_USER: ${DB_USER:-moodleshield}
       POSTGRES_PASSWORD: ${DB_PASSWORD:?falta DB_PASSWORD}
+      # Igual que producción. Sólo surte efecto al crear el cluster: una base ya
+      # inicializada no cambia por esto.
+      POSTGRES_INITDB_ARGS: "--data-checksums"
     volumes:
       - "${DATA_ROOT:?falta DATA_ROOT}/pgdata:/var/lib/postgresql/data:Z"
     ports:
@@ -191,7 +194,7 @@ services:
       timeout: 5s
       retries: 10
       start_period: 20s
-    mem_limit: 256m
+    mem_limit: 512m
     pids_limit: 256
     tmpfs:
       - /tmp:rw,noexec,nosuid,nodev,size=64m
@@ -217,7 +220,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 40s
-    mem_limit: 384m
+    mem_limit: 512m
     pids_limit: 256
     tmpfs:
       - /tmp:rw,noexec,nosuid,nodev,size=64m
@@ -240,8 +243,10 @@ services:
     volumes:
       - "${DATA_ROOT:?falta DATA_ROOT}/media:/data/media:z"
       - "${DATA_ROOT:?falta DATA_ROOT}/uploads:/data/uploads:z"
-    cpus: ${WORKER_CPUS:-1}
-    mem_limit: ${WORKER_MEMORY:-1024m}
+    # ffmpeg necesita margen. Ajusta WORKER_CPUS al número de núcleos que
+    # quieras cederle; el resto del host sigue respondiendo gracias al `nice`.
+    cpus: ${WORKER_CPUS:-4}
+    mem_limit: ${WORKER_MEMORY:-4g}
     pids_limit: 1024
     tmpfs:
       - /tmp:rw,noexec,nosuid,nodev,size=256m
@@ -259,7 +264,7 @@ services:
         condition: service_healthy
     environment:
       MEDIA_LINK_SECRET: ${MEDIA_LINK_SECRET:?falta MEDIA_LINK_SECRET}
-      MAX_UPLOAD_SIZE: ${MAX_UPLOAD_SIZE:-2g}
+      MAX_UPLOAD_SIZE: ${MAX_UPLOAD_SIZE:-4g}
       MAX_CHUNK_SIZE: ${MAX_CHUNK_SIZE:-32m}
     volumes:
       - "${DATA_ROOT:?falta DATA_ROOT}/media:/srv/media:ro,z"

--- a/infra/test/compose.yml
+++ b/infra/test/compose.yml
@@ -30,6 +30,9 @@ x-runtime-hardening: &runtime-hardening
 
 x-app-env: &app-env
   NODE_ENV: production
+  # Literal, NO interpolado: es lo único que no se puede pegar mal desde otro
+  # entorno. NODE_ENV no distingue test de producción; esto sí.
+  MOODLESHIELD_ENV: test
   SERVICE_ROLE: app
   LOG_LEVEL: ${LOG_LEVEL:-debug}
   PUBLIC_URL: ${PUBLIC_URL:?falta PUBLIC_URL}
@@ -99,6 +102,8 @@ x-app-env: &app-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # 0 = sin recorte. 1080 recorta el lado largo y abarata mucho el vídeo vertical.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}
@@ -118,6 +123,9 @@ x-app-env: &app-env
 
 x-worker-env: &worker-env
   NODE_ENV: production
+  # Literal, NO interpolado: es lo único que no se puede pegar mal desde otro
+  # entorno. NODE_ENV no distingue test de producción; esto sí.
+  MOODLESHIELD_ENV: test
   SERVICE_ROLE: worker
   LOG_LEVEL: ${LOG_LEVEL:-debug}
   DB_HOST: db
@@ -148,6 +156,8 @@ x-worker-env: &worker-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # 0 = sin recorte. 1080 recorta el lado largo y abarata mucho el vídeo vertical.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}

--- a/src/config.js
+++ b/src/config.js
@@ -129,6 +129,18 @@ function secret (name, { workerRequired = false } = {}) {
 
 export const config = {
   env: nodeEnv,
+  /**
+   * Qué stack es éste: `test`, `prod` o `local`.
+   *
+   * No sale del bloque de variables sino del **Compose**, literal, sin
+   * interpolar: es el único dato que no se puede pegar mal. `NODE_ENV` no sirve
+   * para esto —vale `production` en test y en producción— y ésa es justo la
+   * confusión que costó dos días: un bloque generado con el perfil `prod`
+   * —`DATA_ROOT=/docker-apps/moodleshield-pro`, la marca imperceptible, la URL
+   * pública de producción— pegado en el stack de test, y nada en pantalla ni en
+   * el log que lo dijera.
+   */
+  deployment: optional('MOODLESHIELD_ENV', ''),
   isProduction,
   serviceRole,
 
@@ -341,6 +353,15 @@ export const config = {
     maxSourceFps: integer('VIDEO_MAX_SOURCE_FPS', 120),
     maxAudioChannels: integer('VIDEO_MAX_AUDIO_CHANNELS', 8),
     maxOutputBitrateKbps: integer('VIDEO_MAX_OUTPUT_BITRATE_KBPS', 8000),
+    /**
+     * Recorta el lado largo de la salida. `0` = sin recorte, que es como se ha
+     * comportado siempre y por eso es el valor por defecto: cambiarlo aquí
+     * cambiaría en silencio la calidad de lo que se transcodifique a partir de
+     * ahora. 1080 es el valor sensato para un reproductor dentro de un iframe
+     * de Moodle, y en fuentes verticales de móvil (1440×1920) divide por tres
+     * los píxeles por fotograma, que se codifican DOS veces.
+     */
+    maxOutputLongSide: integer('VIDEO_MAX_OUTPUT_LONG_SIDE', 0),
     /** Trabajos simultáneos del worker. Con ffmpeg por software, déjalo en 1. */
     concurrency: integer('TRANSCODE_CONCURRENCY', 1),
     /** Cada cuántos ms consulta el worker si hay trabajo nuevo. */

--- a/src/media/transcode.js
+++ b/src/media/transcode.js
@@ -101,11 +101,45 @@ function parseFrameRate (raw) {
  * condición de que A y B corten en los mismos instantes — y se limita a 30:
  * por encima se divide entre dos (60→30, 50→25), que conserva la cadencia.
  */
+/**
+ * Fps de salida. Nada por encima de 30: en una clase grabada no aporta y
+ * duplica el coste de transcodificar.
+ *
+ * Dividir entre dos conserva la cadencia cuando la fuente es un múltiplo
+ * limpio —60→30, 50→25, 48→24— y por eso se hace así. Pero dividir a ciegas
+ * también convertía **32,5 fps en 16**, que se ve a saltos: es el fps que
+ * declara un móvil grabando en modo variable, y no tiene nada de raro. Si la
+ * mitad se queda por debajo de 24, no hay cadencia que conservar y se recorta a
+ * 30, que es remuestrear y no ir a trompicones.
+ */
 export function chooseOutputFps (sourceFps, fallback = config.transcode.fps) {
   if (!Number.isFinite(sourceFps) || sourceFps <= 0) return fallback
+  if (sourceFps <= 30) return Math.max(1, Math.round(sourceFps))
   let fps = sourceFps
   while (fps > 30) fps /= 2
-  return Math.max(1, Math.round(fps))
+  return Math.round(fps) >= 24 ? Math.round(fps) : 30
+}
+
+/**
+ * Recorte del lado largo, si se ha configurado uno.
+ *
+ * No existía: la salida heredaba la resolución de la fuente, así que un vídeo
+ * vertical de móvil a 1440×1920 se codificaba DOS VECES a 2,8 megapíxeles por
+ * fotograma —más que 1080p— para verse dentro de un iframe de Moodle. Recortar
+ * el lado largo a 1080 deja 0,87 Mpx: el mismo vídeo cuesta un tercio.
+ *
+ * `-2` en el otro lado mantiene la proporción y garantiza par, que es lo que
+ * exige yuv420p. El recorte va ANTES de la marca, así que A y B siguen
+ * recibiendo exactamente la misma imagen y sus cortes siguen coincidiendo.
+ */
+export function outputScaleFilter (info, longSide = config.transcode.maxOutputLongSide) {
+  const limite = Number(longSide)
+  if (!Number.isFinite(limite) || limite <= 0) return []
+  const ancho = Number(info?.width)
+  const alto = Number(info?.height)
+  if (!Number.isFinite(ancho) || !Number.isFinite(alto) || ancho <= 0 || alto <= 0) return []
+  if (Math.max(ancho, alto) <= limite) return []
+  return [ancho >= alto ? `scale=${limite}:-2` : `scale=-2:${limite}`]
 }
 
 /** Cota conservadora para las dos variantes, audio y sobrecarga HLS. */
@@ -231,8 +265,14 @@ export async function transcodeVideo (videoId, inputPath, {
   )
   await assertCapacity?.({ videoId, revisionId, estimatedBytes: estimatedArtifactBytes })
   const outputFps = chooseOutputFps(info.fps)
+  // El color se normaliza también para la miniatura; el recorte de tamaño no,
+  // porque la miniatura ya escala a 640 por su cuenta.
   const preFilters = colorFilters(info)
-  log.info({ ...info, outputFps, tonemap: preFilters.length > 0 }, 'Vídeo analizado')
+  const scaleFilters = outputScaleFilter(info)
+  log.info(
+    { ...info, outputFps, tonemap: preFilters.length > 0, scale: scaleFilters[0] ?? null },
+    'Vídeo analizado'
+  )
 
   // Una clave AES por vídeo, compartida por ambas variantes: es lo que permite
   // mezclar segmentos A y B en la misma playlist.
@@ -261,7 +301,7 @@ export async function transcodeVideo (videoId, inputPath, {
         keyInfo: keyInfoFile,
         hasAudio: info.hasAudio,
         fps: outputFps,
-        preFilters
+        preFilters: [...preFilters, ...scaleFilters]
       }),
       {
         onLine: onProgress,

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import config, { assertConfigValid } from './config.js'
 import logger from './logger.js'
+import { appVersion } from './version.js'
 import { createApp } from './app.js'
 import { closeDatabase } from './db/index.js'
 import { getActiveKey } from './lti/keys.js'
@@ -19,7 +20,14 @@ logger.info({ kid: key.kid }, 'Clave de firma de la herramienta lista')
 const app = await createApp()
 const server = app.listen(config.http.port, config.http.host, () => {
   logger.info(
-    { port: config.http.port, publicUrl: config.publicUrl, env: config.env },
+    {
+      port: config.http.port,
+      publicUrl: config.publicUrl,
+      env: config.env,
+      // Cuál de los tres stacks es. `env` vale `production` también en test.
+      deployment: config.deployment || '(sin declarar)',
+      version: appVersion
+    },
     'MoodleShield escuchando'
   )
 })

--- a/src/ui/admin/platform-content.html
+++ b/src/ui/admin/platform-content.html
@@ -9,7 +9,7 @@
 <body class="admin" data-page="platform-content">
   <header class="bar admin-bar">
     <div><p class="eyebrow" id="platformName">MoodleShield</p><h1>Contenido del aula</h1></div>
-    <nav><span class="build" title="Compilación que está sirviendo esta página">{{APP_VERSION}}</span>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span>
       <a class="btn" id="importLink" href="/admin/platforms">Importar contenido</a>
       <a class="btn" id="platformLink" href="/admin/platforms">Configuración del aula</a>
       <a class="btn" href="/admin/platforms">Volver al listado</a>

--- a/src/ui/admin/platform-form.html
+++ b/src/ui/admin/platform-form.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/assets/app.css?v={{ASSET_VERSION}}">
 </head>
 <body class="admin" data-page="platform-form">
-  <header class="bar admin-bar"><div><p class="eyebrow">MoodleShield</p><h1 id="pageTitle">Plataforma Moodle</h1></div><nav><span class="build" title="Compilación que está sirviendo esta página">{{APP_VERSION}}</span><a class="btn" id="contentLink" href="/admin/platforms" hidden>Ver contenido</a> <a class="btn" href="/admin/platforms">Volver al listado</a></nav></header>
+  <header class="bar admin-bar"><div><p class="eyebrow">MoodleShield</p><h1 id="pageTitle">Plataforma Moodle</h1></div><nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span><a class="btn" id="contentLink" href="/admin/platforms" hidden>Ver contenido</a> <a class="btn" href="/admin/platforms">Volver al listado</a></nav></header>
   <main class="admin-main form-layout">
     <section>
       <div id="notice" class="notice error" hidden></div>

--- a/src/ui/admin/platform-import.html
+++ b/src/ui/admin/platform-import.html
@@ -9,7 +9,7 @@
 <body class="admin" data-page="platform-import">
   <header class="bar admin-bar">
     <div><p class="eyebrow" id="platformName">MoodleShield</p><h1>Importar contenido</h1></div>
-    <nav><span class="build" title="Compilación que está sirviendo esta página">{{APP_VERSION}}</span>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span>
       <a class="btn" id="contentLink" href="/admin/platforms">Contenido del aula</a>
       <a class="btn" href="/admin/platforms">Volver al listado</a>
       <form id="logout" method="post" action="/admin/logout"><input type="hidden" name="_csrf"><button>Salir</button></form>

--- a/src/ui/admin/platforms.html
+++ b/src/ui/admin/platforms.html
@@ -9,7 +9,7 @@
 <body class="admin" data-page="platforms">
   <header class="bar admin-bar">
     <div><p class="eyebrow">MoodleShield</p><h1>Instancias Moodle</h1></div>
-    <nav><span class="build" title="Compilación que está sirviendo esta página">{{APP_VERSION}}</span><a class="btn" href="/admin/playback-grants">Sesiones</a><a class="btn primary" href="/admin/platforms/new">Nueva instancia</a>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span><a class="btn" href="/admin/playback-grants">Sesiones</a><a class="btn primary" href="/admin/platforms/new">Nueva instancia</a>
       <form id="logout" method="post" action="/admin/logout"><input type="hidden" name="_csrf"><button>Salir</button></form></nav>
   </header>
   <main class="admin-main">

--- a/src/ui/admin/playback-grants.html
+++ b/src/ui/admin/playback-grants.html
@@ -9,7 +9,7 @@
 <body class="admin" data-page="playback-grants">
   <header class="bar admin-bar">
     <div><p class="eyebrow">MoodleShield</p><h1>Sesiones de reproducción</h1></div>
-    <nav><span class="build" title="Compilación que está sirviendo esta página">{{APP_VERSION}}</span><a class="btn" href="/admin/platforms">Instancias</a>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span><a class="btn" href="/admin/platforms">Instancias</a>
       <form id="logout" method="post" action="/admin/logout"><input type="hidden" name="_csrf"><button>Salir</button></form></nav>
   </header>
   <main class="admin-main">

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -1391,6 +1391,8 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
    la vista de Moodle —ahí el espacio es del material— ni en el login, que es
    deliberadamente anónimo. */
 .admin .build { color: var(--muted); font-size: .75rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .02em; white-space: nowrap; }
+.admin .build-env { color: var(--accent); text-transform: uppercase; letter-spacing: .06em; }
+.admin .build-env:empty { display: none; }
 .login-page { min-height: 100vh; display: grid; place-items: center; }
 .login-card { width: min(100%, 390px); padding: 1.5rem; }
 .login-card form { display: grid; gap: 1rem; margin-top: 1.25rem; }

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -63,6 +63,9 @@ export async function renderPage (name, { bootstrap = {}, ...vars } = {}, { raw 
   // que lee el operador podría no ser el del código que está sirviendo.
   html = html.replaceAll('{{ASSET_VERSION}}', () => encodeURIComponent(appVersion))
   html = html.replaceAll('{{APP_VERSION}}', () => escapeHtml(appVersion))
+  // Qué stack es. Sale del Compose, no del bloque de variables: es lo único que
+  // no se puede pegar mal, y sin ello test y producción son indistinguibles.
+  html = html.replaceAll('{{APP_ENV}}', () => escapeHtml(config.deployment || ''))
   for (const [key, value] of Object.entries(vars)) {
     const rendered = raw.includes(key) ? String(value ?? '') : escapeHtml(value)
     html = html.replaceAll(`{{${key}}}`, () => rendered)

--- a/test/transcode.test.js
+++ b/test/transcode.test.js
@@ -7,6 +7,7 @@ import {
   chooseOutputFps,
   colorFilters,
   estimateVideoArtifactBytes,
+  outputScaleFilter,
   validateProbeData
 } from '../src/media/transcode.js'
 
@@ -59,6 +60,29 @@ test('los fps de salida siguen a la fuente y mantienen el GOP entero', () => {
   assert.equal(chooseOutputFps(120), 30)
   // Un screencast a pocos fps no se infla artificialmente.
   assert.equal(chooseOutputFps(15), 15)
+  // Y dividir sólo vale si al otro lado queda una cadencia. Un móvil grabando
+  // en modo variable declara 32,5: dividir daba 16 fps, que se ve a saltos.
+  assert.equal(chooseOutputFps(32.5), 30)
+  assert.equal(chooseOutputFps(34.4), 30)
+  assert.equal(chooseOutputFps(40), 30)
+  assert.equal(chooseOutputFps(48), 24, 'aquí la mitad sí es una cadencia')
+})
+
+test('el lado largo se recorta sólo si se ha configurado y sólo si sobra', () => {
+  const vertical = { width: 1440, height: 1920 }
+  const apaisado = { width: 3840, height: 2160 }
+
+  assert.deepEqual(outputScaleFilter(vertical, 0), [], 'sin límite, no se toca nada')
+  assert.deepEqual(outputScaleFilter(vertical, 1080), ['scale=-2:1080'],
+    'en vertical el lado largo es el alto')
+  assert.deepEqual(outputScaleFilter(apaisado, 1080), ['scale=1080:-2'],
+    'en apaisado, el ancho')
+  assert.deepEqual(outputScaleFilter({ width: 960, height: 540 }, 1080), [],
+    'lo que ya cabe no se reescala hacia arriba')
+  assert.deepEqual(outputScaleFilter({ width: 1280, height: 720 }, 1080), ['scale=1080:-2'],
+    'y 1280 de lado largo sí pasa del límite, aunque «720p» suene a menos')
+  assert.deepEqual(outputScaleFilter({ width: 0, height: 0 }, 1080), [],
+    'sin dimensiones fiables, no se inventa un filtro')
 })
 
 test('sin fps fiables de la fuente se cae al valor configurado', () => {

--- a/test/version-visible.test.js
+++ b/test/version-visible.test.js
@@ -40,8 +40,10 @@ test('las vistas que se abren dentro de Moodle no la enseñan', async () => {
 
 test('el marcador que se pinta es el mismo que versiona los estáticos', async () => {
   const html = await renderPage('admin/platforms.html', { bootstrap: {} })
-  assert.match(html, new RegExp(`class="build"[^>]*>${appVersion}<`),
+  assert.match(html, new RegExp(`class="build"[^>]*>.*${appVersion}</span>`),
     'la barra debe llevar la compilación en ejecución')
+  assert.match(html, /class="build-env">/,
+    'y el stack al lado: NODE_ENV vale «production» en test y en producción')
   assert.match(html, new RegExp(`app\\.css\\?v=${appVersion}`),
     'y tiene que ser la misma cadena que rompe la caché: si divergen, el número miente')
 })


### PR DESCRIPTION
## Test y producción dejan de diferir

No eran iguales en nueve valores, y **dos de ellos cambian lo que se codifica**:
un test que produce un fichero distinto del que produciría producción no está
probando producción. Test adopta los valores de producción:

| | test (antes) | ahora, los dos |
|---|---:|---:|
| `MARK_ALPHA` | 0.5 | **0.06** |
| `OUTPUT_CRF` | 23 | **21** |
| `LOG_LEVEL` | debug | **info** |
| `MAX_UPLOAD_BYTES` / nginx | 2 GB | **4 GB** |
| `MAX_RESERVED_UPLOAD_BYTES_PER_OWNER` | 4 GB | **8 GB** |
| `MAX_STORED_BYTES_PER_OWNER` | 50 GB | **100 GB** |
| `STORAGE_MIN_FREE_BYTES` | 1 GB | **5 GB** |
| `mem_limit` db / app | 256m / 384m | **512m / 512m** |
| worker | 1 CPU / 1024m | **4 CPU / 4g** |
| `POSTGRES_INITDB_ARGS` | (ausente) | **`--data-checksums`** |

`MARK_ALPHA=0.06` tiene una consecuencia que conviene saber: en test ya no se ve
el patrón A/B a simple vista. Para una comprobación visual, `MARK_ALPHA=0.5` en
Portainer y de vuelta al terminar; el trazado forense funciona igual con 0.06,
que es justo lo que hay que probar.

**Lo único que sigue siendo distinto**: `MOODLESHIELD_ENV` (es el punto),
`HTTP_PORT` (43128/43127: corren en el mismo host), la etiqueta de imagen
(`sha-…` frente a `vX.Y.Z`, que es el modelo de promoción, ADR-028) y el
PostgreSQL publicado en loopback de test para diagnóstico — declarado a
conciencia y quitable con un bloque `ports` menos.

Las líneas equivalentes del Compose de producción están en
`chore/infra-prod-pendiente-promocion`, que es donde el gate permite tocarlas.

## Y lo que salió de mirar el worker con 60 ficheros dentro

- **El stack dice cuál es.** `NODE_ENV` vale `production` en test y en
  producción. Ahora el Compose declara `MOODLESHIELD_ENV` **literal, sin
  interpolar** —lo único que no se puede pegar mal desde otro entorno—, el
  arranque lo escribe junto a la versión y la barra de la consola lo enseña
  delante de la compilación.
- **32,5 fps ya no se convierten en 16.** Dividir entre dos conserva la cadencia
  en 60→30 o 50→25, pero con los 32,5 que declara un móvil en modo variable daba
  16 fps, que se ve a saltos. Si la mitad baja de 24, se recorta a 30.
- **Recorte opcional del lado largo** (`VIDEO_MAX_OUTPUT_LONG_SIDE`, 0 = sin
  recorte). Un vertical de 1440×1920 se codifica **dos veces** a 2,8 Mpx por
  fotograma para verse en un iframe; con 1080 quedan 0,87. Sale apagado porque
  encenderlo cambia la calidad de lo que se transcodifique a partir de ahora.

`npm run lint` limpio y `npm test` en 361 pasados, 0 fallos, 9 saltados (PDF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt