### PR TITLE
feat(colecciones): la biblioteca se elige por carpetas, y una carpeta se convierte en colección

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,8 @@ Encima de ambos: carpetas personales **anidadas** por profesor (ADR-016),
 colecciones que agrupan varios materiales en una sola actividad Moodle, y
 revisiones que permiten sustituir un fichero sin cambiar el UUID que Moodle
 tiene incrustado. La biblioteca del profesor es un explorador de archivos:
-migas + tarjetas de carpeta; la colección se compone en un diálogo con buscador.
+migas + tarjetas de carpeta; la colección se compone en un diálogo que enseña
+la biblioteca por carpetas, con buscador global.
 
 ## Invariantes que no se negocian
 

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -193,6 +193,15 @@ Lo que la importación **no** hace: crear colecciones. Una carpeta del ordenador
 es una carpeta de la biblioteca. Agrupar varios materiales en una sola actividad
 sigue siendo una decisión explícita en el editor de colecciones.
 
+Lo más cerca que se llega es **«Colección con esta carpeta»** (menú «＋ Nuevo»):
+reúne el material de la carpeta abierta y de sus subcarpetas, en orden de
+lectura, y **prellena** el editor proponiendo guardarla en esa misma carpeta. No
+guarda nada por su cuenta —el profesor ve qué entra, en qué orden y con qué
+título— y recorta en `MAX_COLLECTION_ITEMS` diciendo cuántos se han quedado
+fuera. El selector del editor, por lo mismo, enseña la biblioteca **por
+carpetas** y carga cada una al desplegarla: con decenas de ficheros por tema,
+una lista plana por fecha es justo donde no se encuentra nada.
+
 ### La cola no tiene tope; el disco sí
 
 Las cuotas por propietario (F-12, `src/services/upload-limits.js`) no distinguen

--- a/src/lti/routes.js
+++ b/src/lti/routes.js
@@ -230,7 +230,10 @@ ltiRouter.post('/launch', async (req, res, next) => {
             // Habilita «Material de este curso»: sin curso en el launch no hay
             // aula de la que hablar y la vista no se ofrece.
             hasCourse: Boolean(context.contextId),
-            acceptMultiple: Boolean(context.deepLinkingSettings?.accept_multiple)
+            acceptMultiple: Boolean(context.deepLinkingSettings?.accept_multiple),
+            // El editor de colecciones recorta ANTES de mandar y dice cuántos
+            // se quedan fuera; sin el tope aquí sólo lo sabría por el 400.
+            maxCollectionItems: config.catalog.maxCollectionItems
           }
         })
       )
@@ -248,7 +251,8 @@ ltiRouter.post('/launch', async (req, res, next) => {
               mode: 'manage',
               sessionToken,
               hasCourse: Boolean(context.contextId),
-              user: { name: context.name, isInstructor: true }
+              user: { name: context.name, isInstructor: true },
+              maxCollectionItems: config.catalog.maxCollectionItems
             }
           })
         )

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -666,6 +666,10 @@ dialog label { display: block; font-size: .875rem; color: var(--muted); margin-b
   border-radius: var(--radius);
   background: var(--surface-2);
 }
+/* Las dos columnas se desplazan por dentro. Una colección con la carpeta
+   entera son decenas de filas, y dentro del iframe de Moodle —que llega ya
+   recortado— dejarlas crecer empuja «Guardar» fuera de la vista. */
+.collection-items, .collection-picker { max-height: clamp(10rem, 38dvh, 24rem); overflow-y: auto; }
 .collection-items { padding-left: 1.25rem; margin: .25rem 0; }
 .collection-items li { display: flex; align-items: center; gap: .4rem; margin: .25rem 0; }
 .collection-items .item-label { flex: 1; min-width: 0; overflow-wrap: anywhere; }
@@ -673,8 +677,6 @@ dialog label { display: block; font-size: .875rem; color: var(--muted); margin-b
   list-style: none;
   margin: .25rem 0 0;
   padding: 0;
-  max-height: 18rem;
-  overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
@@ -687,6 +689,28 @@ dialog label { display: block; font-size: .875rem; color: var(--muted); margin-b
 }
 .collection-picker li:first-child { border-top: 0; }
 .collection-picker .item-label { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+
+/* El selector es un árbol de carpetas, no una lista plana: la sangría es lo
+   único que dice de qué carpeta cuelga cada material. */
+.collection-picker li { padding-left: calc(.6rem + var(--picker-depth, 0) * .9rem); }
+.picker-folder { background: var(--surface); }
+.picker-folder-toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+  border: 0;
+  background: none;
+  padding: .1rem 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+.picker-folder-name { font-weight: 600; overflow-wrap: anywhere; }
+.picker-twisty { flex: none; width: 1rem; color: var(--muted); font-size: .7rem; }
+.picker-add-all { flex: none; }
+.picker-note { display: block; }
 
 #revision-list { list-style: none; padding: 0; }
 #revision-list li {

--- a/src/ui/assets/catalog.js
+++ b/src/ui/assets/catalog.js
@@ -65,6 +65,14 @@ const state = {
   collectionDraft: { editing: null, items: [] },
   pickerResults: [],
   pickerNextCursor: null,
+  /**
+   * Selector de materiales del editor de colección. Se carga POR CARPETA y no
+   * de golpe: con la biblioteca real —decenas de ficheros por tema— una lista
+   * plana de todo el material es justo donde no se encuentra nada. `porCarpeta`
+   * guarda lo ya traído de cada una ('root' = material sin carpeta) para que
+   * plegar y volver a desplegar no cueste otra petición.
+   */
+  picker: { query: '', expanded: new Set(), porCarpeta: new Map() },
   /** Elemento al que devolver el foco tras una mutación. */
   focusAfterReload: null,
   /**
@@ -1706,14 +1714,19 @@ function openNewCollection () {
   el('collection-folder').disabled = false
   el('collection-save').textContent = 'Guardar'
   configureCollectionActions()
-  el('collection-search').value = ''
-  state.pickerResults = []
-  state.pickerNextCursor = null
   dialogStatus('collection-error')
+  avisoColeccion()
   renderCollectionItems()
-  void loadPicker()
+  resetPicker(destinationFolderId())
   abrirDialogo(el('collection-dialog'))
   el('collection-title').focus()
+}
+
+/** Explica de dónde sale lo que ya está puesto en el borrador. Sin drama: no es un error. */
+function avisoColeccion (mensaje = '') {
+  const node = el('collection-hint')
+  node.textContent = mensaje
+  node.hidden = !mensaje
 }
 
 /**
@@ -1746,18 +1759,100 @@ async function openCollectionEditor (collection) {
     folderSelect.disabled = isShared(full)
     el('collection-save').textContent = 'Guardar cambios'
     configureCollectionActions()
-    el('collection-search').value = ''
-    state.pickerResults = []
-    state.pickerNextCursor = null
     dialogStatus('collection-error')
+    avisoColeccion()
     renderCollectionItems()
-    void loadPicker()
+    resetPicker(full.folderId ?? null)
     abrirDialogo(el('collection-dialog'))
     el('collection-title').focus()
   } catch (err) {
     if (generation !== collectionEditorGeneration) return
     notify(err.message, 'error')
   }
+}
+
+/**
+ * «Colección con esta carpeta»: el caso normal después de importar un tema
+ * entero. Prellena el editor con el material de la carpeta abierta y de sus
+ * subcarpetas, en orden de lectura, y propone guardarla en esa misma carpeta.
+ *
+ * No crea nada por su cuenta a propósito: el diálogo enseña qué va dentro y en
+ * qué orden antes de guardar, que es justo lo que el profesor va a querer
+ * retocar. Guardar sigue siendo el mismo POST de siempre.
+ */
+async function openCollectionFromFolder () {
+  const folder = state.view === 'browse' ? folderById(state.folderId) : null
+  if (!folder) {
+    notify('Abre antes la carpeta con la que quieras hacer la colección', 'error')
+    return
+  }
+  const generation = ++collectionEditorGeneration
+  clearTimeout(pickerTimer)
+  const carpetas = [folder.id, ...subarbolEnOrden(folder.id)]
+  let grupos
+  try {
+    grupos = await Promise.all(carpetas.map(async (id) => {
+      const params = new URLSearchParams({ folderId: id, limit: '200' })
+      const data = await apiJson(`/materials?${params}`)
+      return [id, {
+        ...grupoVacio(),
+        materials: ordenLectura(insertables(data.materials)),
+        nextCursor: data.nextCursor,
+        cargado: true
+      }]
+    }))
+  } catch (err) {
+    if (generation === collectionEditorGeneration) {
+      notify(`No se pudo leer el material de la carpeta: ${err.message}`, 'error')
+    }
+    return
+  }
+  if (generation !== collectionEditorGeneration) return
+
+  const todos = grupos.flatMap(([, grupo]) => grupo.materials)
+  if (todos.length === 0) {
+    notify(`«${folder.name}» no tiene material que se pueda insertar`, 'error')
+    return
+  }
+  const dentro = todos.slice(0, topeColeccion())
+
+  state.collectionDraft = {
+    editing: null,
+    items: dentro.map((m) => ({ kind: m.kind, id: m.id, title: m.title }))
+  }
+  el('collection-heading').textContent = `Nueva colección con «${folder.name}»`
+  el('collection-title').value = folder.name
+  el('collection-description').value = ''
+  const destino = el('collection-folder')
+  destino.replaceChildren(...folderOptions({ rootLabel: 'Biblioteca' }))
+  // Una carpeta compartida es de su autor: se puede usar lo que hay dentro,
+  // pero lo que se crea se guarda en la biblioteca propia.
+  destino.value = isShared(folder) ? '' : folder.id
+  destino.disabled = false
+  el('collection-save').textContent = 'Guardar'
+  configureCollectionActions()
+  dialogStatus('collection-error')
+
+  const expanded = new Set(carpetas)
+  for (const ancestro of pathOf(folder.id)) expanded.add(ancestro.id)
+  state.picker = { query: '', expanded, porCarpeta: new Map(grupos) }
+  state.pickerResults = []
+  state.pickerNextCursor = null
+  el('collection-search').value = ''
+  renderCollectionItems()
+  renderPicker()
+
+  const subcarpetas = carpetas.length - 1
+  avisoColeccion(
+    `Se han añadido ${dentro.length} material${dentro.length === 1 ? '' : 'es'} de «${folder.name}»` +
+    (subcarpetas ? ` y sus ${subcarpetas} subcarpeta${subcarpetas === 1 ? '' : 's'}` : '') +
+    (todos.length > dentro.length
+      ? `. ${mensajeTope()} Se han quedado fuera ${todos.length - dentro.length}.`
+      : '. Quita lo que no quieras y ordénalo antes de guardar.') +
+    (isShared(folder) ? ` La carpeta es de ${ownerLabel(folder)}: la colección se guarda en tu biblioteca.` : '')
+  )
+  abrirDialogo(el('collection-dialog'))
+  el('collection-title').focus()
 }
 
 function renderCollectionItems () {
@@ -1808,8 +1903,125 @@ function renderCollectionItems () {
   }))
 }
 
+// ---------------------------------------------------------------------------
+// Selector de materiales: la biblioteca, por carpetas
+// ---------------------------------------------------------------------------
+
+/** Clave del grupo «sin carpeta»; es lo que entiende `/materials?folderId=`. */
+const PICKER_RAIZ = 'root'
+
+/** Insertable: publicado o aún en cola —el alumno lo verá al procesarse—, sin archivar. */
+function insertables (materials) {
+  return materials.filter((m) =>
+    !m.archived && (m.hasActiveRevision || INSERTABLE_STATUSES.has(m.status)))
+}
+
+/**
+ * Orden natural dentro de una carpeta. El explorador ordena por fecha, pero una
+ * colección se lee como un temario: «10 · …» tiene que ir detrás de «9 · …» y
+ * no delante, que es lo que haría un orden alfabético a secas.
+ */
+function ordenLectura (materials) {
+  return [...materials].sort((a, b) =>
+    String(a.title).localeCompare(String(b.title), 'es', { numeric: true, sensitivity: 'base' }))
+}
+
+/** Tope de materiales por colección; lo dice el servidor en el bootstrap. */
+function topeColeccion () {
+  const declarado = Number(boot.maxCollectionItems)
+  return Number.isFinite(declarado) && declarado > 0 ? declarado : 50
+}
+
+function mensajeTope () {
+  return `Una colección admite como máximo ${topeColeccion()} materiales.`
+}
+
+/** Vídeos y PDF de la carpeta y de todo lo que cuelga de ella. */
+function materialesEnSubarbol (id) {
+  const folder = folderById(id)
+  if (!folder) return 0
+  let total = Number(folder.videoCount ?? 0) + Number(folder.documentCount ?? 0)
+  for (const child of childrenOf(id)) total += materialesEnSubarbol(child.id)
+  return total
+}
+
+/** Subcarpetas en orden de lectura (primero en profundidad), como en el árbol. */
+function subarbolEnOrden (id) {
+  const out = []
+  const walk = (parentId) => {
+    for (const child of childrenOf(parentId)) {
+      out.push(child.id)
+      walk(child.id)
+    }
+  }
+  walk(id)
+  return out
+}
+
+/**
+ * Carpetas del selector, en el orden en que se leen y sólo hasta donde se ha
+ * desplegado. Las que no tienen material en todo su subárbol no salen: aquí no
+ * se organiza la biblioteca, se elige material, y una rama vacía sólo estorba.
+ */
+function carpetasDelPicker () {
+  const out = []
+  const walk = (parentId, shared) => {
+    for (const child of childrenOf(parentId)) {
+      if (isShared(child) !== shared) continue
+      if (materialesEnSubarbol(child.id) === 0) continue
+      out.push(child)
+      if (state.picker.expanded.has(child.id)) walk(child.id, shared)
+    }
+  }
+  walk(null, false)
+  walk(null, true)
+  return out
+}
+
+function grupoPicker (key) {
+  return state.picker.porCarpeta.get(key) ?? null
+}
+
+function grupoVacio () {
+  return { materials: [], nextCursor: null, cargado: false, cargando: false, error: null }
+}
+
+/**
+ * Trae el material de UNA carpeta. `key` es 'root' o el UUID, tal cual lo
+ * entiende `/materials?folderId=`. El material compartido entra por la misma
+ * puerta: la carpeta es de otro profesor, pero se ve porque la publicó.
+ */
+async function loadPickerFolder (key, { append = false } = {}) {
+  const generation = collectionEditorGeneration
+  const grupo = grupoPicker(key) ?? grupoVacio()
+  if (grupo.cargando) return
+  if (append && !grupo.nextCursor) return
+  grupo.cargando = true
+  grupo.error = null
+  state.picker.porCarpeta.set(key, grupo)
+  renderPicker()
+  try {
+    const params = new URLSearchParams({ folderId: key, limit: '200' })
+    if (append && grupo.nextCursor) params.set('cursor', grupo.nextCursor)
+    const data = await apiJson(`/materials?${params}`)
+    if (generation !== collectionEditorGeneration) return
+    const traido = insertables(data.materials)
+    grupo.materials = ordenLectura(
+      uniqueBy(append ? [...grupo.materials, ...traido] : traido, (m) => `${m.kind}:${m.id}`))
+    grupo.nextCursor = data.nextCursor
+    grupo.cargado = true
+  } catch (err) {
+    if (generation !== collectionEditorGeneration) return
+    grupo.error = err.message
+  } finally {
+    grupo.cargando = false
+    if (generation === collectionEditorGeneration) renderPicker()
+  }
+}
+
 let pickerGeneration = 0
 
+/** Búsqueda: ahí la lista sí va plana, porque ya viene filtrada por el término. */
 async function loadPicker ({ append = false } = {}) {
   const cursor = append ? state.pickerNextCursor : null
   if (append && !cursor) return
@@ -1823,12 +2035,8 @@ async function loadPicker ({ append = false } = {}) {
   try {
     const data = await apiJson(`/materials?${params}`)
     if (generation !== pickerGeneration) return
-    // Lo insertable: publicado o aún en cola (el alumno lo verá al procesarse),
-    // sin archivar. Misma regla que la inserción de material suelto.
-    const insertable = data.materials.filter((m) =>
-      !m.archived && (m.hasActiveRevision || INSERTABLE_STATUSES.has(m.status)))
-    const combined = append ? [...state.pickerResults, ...insertable] : insertable
-    state.pickerResults = [...new Map(combined.map((item) => [`${item.kind}:${item.id}`, item])).values()]
+    const combined = append ? [...state.pickerResults, ...insertables(data.materials)] : insertables(data.materials)
+    state.pickerResults = uniqueBy(combined, (item) => `${item.kind}:${item.id}`)
     state.pickerNextCursor = data.nextCursor
     renderPicker()
   } catch (err) {
@@ -1839,47 +2047,213 @@ async function loadPicker ({ append = false } = {}) {
   }
 }
 
-function renderPicker () {
-  const chosen = new Set(state.collectionDraft.items.map((s) => `${s.kind}:${s.id}`))
-  el('collection-picker').replaceChildren(...state.pickerResults.map((material) => {
-    const li = document.createElement('li')
-    const label = document.createElement('span')
-    label.className = 'item-label'
-    const name = document.createElement('span')
-    name.textContent = `${material.kind === 'pdf' ? 'PDF' : 'Vídeo'} · ${material.title}`
-    const where = document.createElement('span')
-    where.className = 'muted'
-    // La insignia de estado avisa de que se añade algo aún en preparación.
-    where.textContent = ` — en ${pathName(material.folderId)}` +
-      (isShared(material) ? ` · de ${ownerLabel(material)}` : '') +
-      (material.status !== 'ready' ? ` · ${STATUS_LABEL[material.status] ?? material.status}` : '')
-    label.append(name, where)
+/**
+ * Añade respetando el tope de la colección. Devuelve cuántos entraron y cuántos
+ * se quedaron fuera: recortar en silencio dejaría al profesor creyendo que ha
+ * metido la carpeta entera.
+ */
+function sumarAlBorrador (materiales) {
+  const items = state.collectionDraft.items
+  const yaEstan = new Set(items.map((s) => `${s.kind}:${s.id}`))
+  const nuevos = materiales.filter((m) => !yaEstan.has(`${m.kind}:${m.id}`))
+  const hueco = Math.max(0, topeColeccion() - items.length)
+  for (const material of nuevos.slice(0, hueco)) {
+    items.push({ kind: material.kind, id: material.id, title: material.title })
+  }
+  renderCollectionItems()
+  renderPicker()
+  return { sumados: Math.min(nuevos.length, hueco), fuera: Math.max(0, nuevos.length - hueco) }
+}
 
-    const toggle = document.createElement('button')
-    toggle.type = 'button'
-    const key = `${material.kind}:${material.id}`
-    toggle.textContent = chosen.has(key) ? 'Quitar' : 'Añadir'
-    toggle.addEventListener('click', () => {
-      const items = state.collectionDraft.items
-      const at = items.findIndex((s) => s.kind === material.kind && s.id === material.id)
-      if (at >= 0) items.splice(at, 1)
-      else items.push({ kind: material.kind, id: material.id, title: material.title })
+function filaAviso (texto, sangria = 0) {
+  const li = document.createElement('li')
+  li.className = 'picker-note muted'
+  li.style.setProperty('--picker-depth', String(sangria))
+  li.textContent = texto
+  return li
+}
+
+function filaMaterial (material, { elegidos, sangria = 0, conRuta = false }) {
+  const li = document.createElement('li')
+  li.className = 'picker-item'
+  li.style.setProperty('--picker-depth', String(sangria))
+
+  const label = document.createElement('span')
+  label.className = 'item-label'
+  const name = document.createElement('span')
+  name.textContent = `${material.kind === 'pdf' ? 'PDF' : 'Vídeo'} · ${material.title}`
+  const where = document.createElement('span')
+  where.className = 'muted'
+  // La insignia de estado avisa de que se añade algo aún en preparación.
+  where.textContent =
+    (conRuta ? ` — en ${pathName(material.folderId)}` : '') +
+    (isShared(material) ? ` · de ${ownerLabel(material)}` : '') +
+    (material.status !== 'ready' ? ` · ${STATUS_LABEL[material.status] ?? material.status}` : '')
+  label.append(name, where)
+
+  const key = `${material.kind}:${material.id}`
+  const puesto = elegidos.has(key)
+  const toggle = document.createElement('button')
+  toggle.type = 'button'
+  toggle.textContent = puesto ? 'Quitar' : 'Añadir'
+  toggle.setAttribute('aria-label', `${puesto ? 'Quitar' : 'Añadir'} ${material.title}`)
+  toggle.addEventListener('click', () => {
+    const items = state.collectionDraft.items
+    const at = items.findIndex((s) => s.kind === material.kind && s.id === material.id)
+    if (at >= 0) {
+      items.splice(at, 1)
       renderCollectionItems()
       renderPicker()
-    })
+      return
+    }
+    const { fuera } = sumarAlBorrador([material])
+    if (fuera) dialogStatus('collection-error', mensajeTope(), { error: true })
+  })
 
-    li.append(label, toggle)
-    return li
-  }))
-  el('collection-picker-more').hidden = !state.pickerNextCursor
+  li.append(label, toggle)
+  return li
+}
+
+/** Cabecera de un grupo, con su contenido debajo si está desplegado. */
+function filasDeCarpeta (folder, elegidos) {
+  const key = folder ? folder.id : PICKER_RAIZ
+  const nombre = folder ? folder.name : 'Sin carpeta'
+  const sangria = folder ? Math.max(0, pathOf(folder.id).length - 1) : 0
+  const abierta = state.picker.expanded.has(key)
+  const grupo = grupoPicker(key)
+  // Antes de traer nada vale la cuenta del árbol; después manda lo que de
+  // verdad se puede insertar, que descuenta lo fallido y lo que sigue subiendo.
+  const propios = grupo?.cargado && !grupo.nextCursor
+    ? grupo.materials.length
+    : folder
+      ? Number(folder.videoCount ?? 0) + Number(folder.documentCount ?? 0)
+      : Number(state.root?.videoCount ?? 0) + Number(state.root?.documentCount ?? 0)
+
+  const li = document.createElement('li')
+  li.className = 'picker-folder'
+  li.style.setProperty('--picker-depth', String(sangria))
+
+  const toggle = document.createElement('button')
+  toggle.type = 'button'
+  toggle.className = 'picker-folder-toggle'
+  toggle.setAttribute('aria-expanded', String(abierta))
+  const flecha = document.createElement('span')
+  flecha.className = 'picker-twisty'
+  flecha.setAttribute('aria-hidden', 'true')
+  flecha.textContent = abierta ? '▾' : '▸'
+  const texto = document.createElement('span')
+  texto.className = 'picker-folder-name'
+  texto.textContent = nombre
+  const cuenta = document.createElement('span')
+  cuenta.className = 'muted'
+  cuenta.textContent = `${propios} material${propios === 1 ? '' : 'es'}` +
+    (folder && isShared(folder) ? ` · de ${ownerLabel(folder)}` : '')
+  toggle.append(flecha, texto, cuenta)
+  toggle.addEventListener('click', () => {
+    if (abierta) state.picker.expanded.delete(key)
+    else {
+      state.picker.expanded.add(key)
+      if (!grupoPicker(key)?.cargado) void loadPickerFolder(key)
+    }
+    renderPicker()
+  })
+
+  const todo = document.createElement('button')
+  todo.type = 'button'
+  todo.className = 'picker-add-all'
+  todo.textContent = 'Añadir todo'
+  todo.setAttribute('aria-label', `Añadir los ${propios} materiales de ${nombre}`)
+  todo.disabled = propios === 0
+  todo.addEventListener('click', async () => {
+    state.picker.expanded.add(key)
+    if (!grupoPicker(key)?.cargado) await loadPickerFolder(key)
+    const traido = grupoPicker(key)
+    if (!traido || traido.materials.length === 0) {
+      dialogStatus('collection-error',
+        `«${nombre}» no tiene material que se pueda insertar.`, { error: true })
+      return
+    }
+    const { fuera } = sumarAlBorrador(traido.materials)
+    dialogStatus('collection-error',
+      fuera ? `${mensajeTope()} Se han quedado fuera ${fuera}.` : '',
+      { error: Boolean(fuera) })
+  })
+
+  li.append(toggle, todo)
+  const filas = [li]
+  if (!abierta) return filas
+
+  if (!grupo || (grupo.cargando && !grupo.cargado)) {
+    filas.push(filaAviso('Cargando…', sangria + 1))
+  } else if (grupo.error) {
+    filas.push(filaAviso(`No se pudo cargar: ${grupo.error}`, sangria + 1))
+  } else if (grupo.materials.length === 0) {
+    filas.push(filaAviso('Sin material que se pueda insertar', sangria + 1))
+  } else {
+    for (const material of grupo.materials) {
+      filas.push(filaMaterial(material, { elegidos, sangria: sangria + 1 }))
+    }
+  }
+  if (grupo?.nextCursor) {
+    const fila = document.createElement('li')
+    fila.className = 'picker-note'
+    fila.style.setProperty('--picker-depth', String(sangria + 1))
+    const mas = document.createElement('button')
+    mas.type = 'button'
+    mas.textContent = 'Mostrar más de esta carpeta'
+    mas.disabled = Boolean(grupo.cargando)
+    mas.addEventListener('click', () => { void loadPickerFolder(key, { append: true }) })
+    fila.append(mas)
+    filas.push(fila)
+  }
+  return filas
+}
+
+function renderPicker () {
+  const elegidos = new Set(state.collectionDraft.items.map((s) => `${s.kind}:${s.id}`))
+  const buscando = Boolean(state.picker.query)
+  const filas = []
+  if (buscando) {
+    for (const material of state.pickerResults) {
+      filas.push(filaMaterial(material, { elegidos, conRuta: true }))
+    }
+    if (filas.length === 0) filas.push(filaAviso('Ningún material coincide con la búsqueda'))
+  } else {
+    const enRaiz = Number(state.root?.videoCount ?? 0) + Number(state.root?.documentCount ?? 0)
+    if (enRaiz > 0) filas.push(...filasDeCarpeta(null, elegidos))
+    for (const folder of carpetasDelPicker()) filas.push(...filasDeCarpeta(folder, elegidos))
+    if (filas.length === 0) filas.push(filaAviso('Todavía no hay material en la biblioteca'))
+  }
+  el('collection-picker').replaceChildren(...filas)
+  el('collection-picker-hint').hidden = buscando
+  el('collection-picker-more').hidden = !(buscando && state.pickerNextCursor)
+}
+
+/**
+ * Deja el selector como recién abierto y con la carpeta de partida a la vista,
+ * que es donde el profesor va a buscar casi siempre.
+ */
+function resetPicker (folderId) {
+  state.picker = { query: '', expanded: new Set(), porCarpeta: new Map() }
+  state.pickerResults = []
+  state.pickerNextCursor = null
+  el('collection-search').value = ''
+  for (const ancestro of pathOf(folderId)) state.picker.expanded.add(ancestro.id)
+  const key = folderId ?? PICKER_RAIZ
+  state.picker.expanded.add(key)
+  renderPicker()
+  void loadPickerFolder(key)
 }
 
 let pickerTimer = null
 el('collection-search').addEventListener('input', () => {
   clearTimeout(pickerTimer)
   pickerTimer = setTimeout(() => {
+    state.picker.query = el('collection-search').value.trim()
     state.pickerNextCursor = null
-    void loadPicker()
+    state.pickerResults = []
+    if (state.picker.query) void loadPicker()
+    else renderPicker()
   }, 300)
 })
 el('collection-picker-more').addEventListener('click', () => { void loadPicker({ append: true }) })
@@ -2309,12 +2683,32 @@ const newMenu = menuFlotante(el('new-menu'))
 for (const [id, run] of [
   ['upload-open', openUpload],
   ['new-folder', () => { void createFolder() }],
-  ['new-collection', openNewCollection]
+  ['new-collection', openNewCollection],
+  ['new-collection-folder', () => { void openCollectionFromFolder() }]
 ]) {
   el(id).addEventListener('click', () => {
     newMenu.open = false
     run()
   })
+}
+
+// «Colección con esta carpeta» actúa sobre la carpeta abierta: si no hay
+// ninguna, la opción se apaga y dice por qué, en vez de fallar al pulsarla.
+el('new-menu').addEventListener('toggle', () => {
+  const folder = state.view === 'browse' ? folderById(state.folderId) : null
+  const boton = el('new-collection-folder')
+  boton.disabled = !folder
+  boton.textContent = folder
+    ? `Colección con «${recortar(folder.name, 24)}»…`
+    : 'Colección con esta carpeta…'
+  boton.title = folder
+    ? `Reúne el material de «${folder.name}» y de sus subcarpetas`
+    : 'Abre una carpeta para usar esta opción'
+})
+
+/** Nombres largos en un menú flotante lo estiran hasta salirse de la barra. */
+function recortar (texto, largo) {
+  return texto.length > largo ? `${texto.slice(0, largo - 1)}…` : texto
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/catalog.html
+++ b/src/ui/catalog.html
@@ -92,6 +92,7 @@
             <button id="import-open" type="button">Importar una carpeta…</button>
             <button id="new-folder" type="button">Nueva carpeta…</button>
             <button id="new-collection" type="button">Nueva colección…</button>
+            <button id="new-collection-folder" type="button">Colección con esta carpeta…</button>
           </div>
         </details>
       </div>
@@ -324,6 +325,7 @@
         <label for="collection-folder">Guardar en la carpeta</label>
         <select id="collection-folder"></select>
       </p>
+      <p id="collection-hint" class="muted" hidden></p>
       <p id="collection-error" class="dialog-error" role="alert" tabindex="-1" hidden></p>
 
       <div class="collection-editor-grid">
@@ -338,10 +340,14 @@
         <section>
           <h3>Añadir materiales</h3>
           <p>
-            <input type="search" id="collection-search" placeholder="Buscar materiales listos"
+            <input type="search" id="collection-search" placeholder="Buscar en toda la biblioteca"
                    aria-label="Buscar materiales para añadir">
           </p>
-          <ul id="collection-picker" class="collection-picker"></ul>
+          <p class="muted" id="collection-picker-hint">
+            Despliega una carpeta para ver su material. «Añadir todo» mete la carpeta entera.
+          </p>
+          <ul id="collection-picker" class="collection-picker"
+              aria-label="Material de la biblioteca, por carpetas"></ul>
           <p class="load-more-row">
             <button type="button" id="collection-picker-more" hidden>Mostrar más materiales</button>
           </p>

--- a/test/ui-catalogo.test.js
+++ b/test/ui-catalogo.test.js
@@ -51,3 +51,76 @@ test('las vistas que no son carpetas van fuera de «Mis carpetas»', async () =>
   assert.ok(html.slice(seccion).indexOf('</section>') < html.slice(seccion).indexOf('course-toggle'),
     'no pueden quedar dentro de la sección de carpetas')
 })
+
+/**
+ * Componer una colección con la biblioteca real —60 ficheros repartidos por
+ * temas— era imposible con una lista plana: el selector traía «los últimos 60
+ * por fecha» y el material de un tema salía mezclado con el de otro. El
+ * selector se carga por carpeta, igual que se navega la biblioteca.
+ */
+test('el selector de la colección pide el material carpeta a carpeta', async () => {
+  const code = await readFile(path.join(uiDir, 'assets/catalog.js'), 'utf8')
+  assert.match(code, /async function loadPickerFolder \(key, \{ append = false \} = \{\}\)/,
+    'falta la carga por carpeta')
+  assert.match(code, /new URLSearchParams\(\{ folderId: key, limit: '200' \}\)/,
+    'cada grupo se pide con su folderId, no todo el catálogo de golpe')
+  assert.match(code, /porCarpeta: new Map\(\)/,
+    'lo ya traído se guarda: plegar y desplegar no puede costar otra petición')
+  assert.match(code, /for \(const folder of carpetasDelPicker\(\)\) filas\.push\(\.\.\.filasDeCarpeta\(folder, elegidos\)\)/,
+    'el selector se dibuja como árbol de carpetas')
+  assert.doesNotMatch(code, /^\s*void loadPicker\(\)$/m,
+    'abrir el editor ya no carga la lista plana: eso es sólo la búsqueda')
+})
+
+/**
+ * El tope de materiales por colección lo pone el servidor
+ * (`MAX_COLLECTION_ITEMS`, 50 por defecto, que es el rango del `position` de la
+ * tabla). «Añadir todo» de una carpeta grande lo alcanza sin querer, así que el
+ * editor lo conoce para recortar diciéndolo y no comerse un 400.
+ */
+test('el editor conoce el tope de la colección y lo dice al recortar', async () => {
+  const code = await readFile(path.join(uiDir, 'assets/catalog.js'), 'utf8')
+  const rutas = await readFile(new URL('../src/lti/routes.js', import.meta.url), 'utf8')
+  assert.match(rutas, /maxCollectionItems: config\.catalog\.maxCollectionItems/,
+    'el tope tiene que viajar en el bootstrap')
+  assert.equal((rutas.match(/maxCollectionItems: config\.catalog\.maxCollectionItems/g) ?? []).length, 2,
+    'los dos modos del catálogo (deeplink y manage) abren el mismo editor')
+  assert.match(code, /Number\(boot\.maxCollectionItems\)/, 'el editor debe leerlo del bootstrap')
+  assert.match(code, /Se han quedado fuera \$\{fuera\}/,
+    'lo que no cabe se dice; recortar en silencio engaña sobre lo que se guardó')
+})
+
+/**
+ * Después de importar un tema entero, lo que el profesor quiere es una
+ * actividad con ese tema. La opción prellena el editor —no crea nada sola— y
+ * propone guardar la colección en la misma carpeta de la que sale.
+ */
+test('«Nuevo» ofrece la colección de la carpeta abierta', async () => {
+  const html = await readFile(path.join(uiDir, 'catalog.html'), 'utf8')
+  const code = await readFile(path.join(uiDir, 'assets/catalog.js'), 'utf8')
+  assert.match(html, /id="new-collection-folder"/, 'falta la opción en el menú «＋ Nuevo»')
+  assert.match(code, /\['new-collection-folder', \(\) => \{ void openCollectionFromFolder\(\) \}\]/,
+    'la opción tiene que estar cableada')
+  assert.match(code, /const carpetas = \[folder\.id, \.\.\.subarbolEnOrden\(folder\.id\)\]/,
+    'una carpeta importada tiene el material en sus subcarpetas: hay que bajar')
+  assert.match(code, /destino\.value = isShared\(folder\) \? '' : folder\.id/,
+    'se guarda en la misma carpeta, salvo que sea de otro profesor')
+  assert.match(code, /boton\.disabled = !folder/,
+    'sin carpeta abierta la opción no puede hacer nada: se apaga')
+})
+
+/**
+ * Una colección se lee como un temario. Con orden alfabético a secas, «10 · …»
+ * se cuela delante de «9 · …» y el profesor tiene que reordenar a mano justo lo
+ * que la opción venía a ahorrarle.
+ */
+test('el material se ordena como se lee, con los números en su sitio', async () => {
+  const code = await readFile(path.join(uiDir, 'assets/catalog.js'), 'utf8')
+  assert.match(code, /localeCompare\(String\(b\.title\), 'es', \{ numeric: true, sensitivity: 'base' \}\)/,
+    'sin `numeric` el 10 adelanta al 9')
+  const titulos = ['10 · Repaso', '2 · Límites', '9 · Derivadas']
+  assert.deepEqual(
+    [...titulos].sort((a, b) => a.localeCompare(b, 'es', { numeric: true, sensitivity: 'base' })),
+    ['2 · Límites', '9 · Derivadas', '10 · Repaso']
+  )
+})


### PR DESCRIPTION
## Qué cambia

**1) El selector de materiales del editor de colección deja de ser una lista plana.**
Traía «los últimos 60 por fecha» de toda la biblioteca, así que con 60 ficheros
repartidos por temas el material de uno salía mezclado con el de otro. Ahora es
el mismo árbol que la biblioteca: carpetas plegadas con su cuenta, cada una se
carga al desplegarla, lo traído se queda (plegar y volver a desplegar no cuesta
otra petición) y cada grupo trae **«Añadir todo»**. Las ramas sin material no
aparecen. Buscar sigue dando la lista plana de siempre, con su ruta al lado.

**2) «Colección con esta carpeta», en el menú «＋ Nuevo».**
Reúne el material de la carpeta abierta **y de sus subcarpetas**, en orden de
lectura, y **prellena** el editor proponiendo guardar la colección en esa misma
carpeta. No guarda nada por su cuenta: el profesor ve qué entra, en qué orden y
con qué título antes de decidir. Sin carpeta abierta la opción se apaga y dice
por qué; si la carpeta es de otro profesor, la colección se guarda en la
biblioteca propia y se avisa.

**3) El tope de la colección viaja en el bootstrap.**
`MAX_COLLECTION_ITEMS` (50, que es el rango del `position` de la tabla) llega al
navegador: se recorta antes de mandar y se dice cuántos se han quedado fuera, en
vez de comerse un 400 o guardar menos de lo que el profesor cree.

## Compatibilidad

Nada exige rehacer lo ya desplegado: las colecciones existentes se editan igual,
con su mismo UUID, su control optimista y el mismo `POST`/`PATCH`. Del lado del
servidor sólo se añade un campo al bootstrap del catálogo.

## Comprobado

`npm test` (365) y `npm run lint` en verde, con cuatro pruebas nuevas. Además,
banco de pruebas con la API simulada —67 materiales en 4 carpetas anidadas, una
compartida y una vacía— para ver el árbol, la carga perezosa, la caché al
plegar, la búsqueda, «Añadir todo» sobre una carpeta aún sin cargar y el recorte
en 50 con su aviso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt