### PR TITLE
feat(guardia): la Regla 0 deja de ser prosa — lo destructivo se corta antes de ocurrir

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/tools/guardia-datos.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,38 @@ jobs:
           fi
           echo "Sin cambios en infra/prod/."
 
+  # Una migración ya publicada no vuelve a ejecutarse donde ya corrió: editarla
+  # no arregla nada y separa en silencio el esquema de producción del que
+  # describe el repositorio. Peor si el cambio es destructivo, porque CI las
+  # aplica sobre una base vacía, donde un DROP no duele. Aquí sólo se comprueba
+  # que nadie toca las de antes; que las nuevas sean aditivas lo vigila
+  # `test/guardia-datos.test.js`.
+  migraciones-inmutables:
+    name: Migraciones inmutables
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Las migraciones de antes no se editan ni se borran
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE"
+          tocadas=$(git diff --name-only --diff-filter=MDR "origin/${BASE}...HEAD" -- migrations/)
+          if [ -n "$tocadas" ]; then
+            echo "::error::Estas migraciones ya estaban publicadas y esta PR las cambia o las borra:"
+            echo "$tocadas"
+            echo "Son inmutables por contrato: va una migración NUEVA, numerada, aditiva y reejecutable."
+            exit 1
+          fi
+          nuevas=$(git diff --name-only --diff-filter=A "origin/${BASE}...HEAD" -- migrations/ || true)
+          echo "Migraciones nuevas en esta PR: ${nuevas:-ninguna}"
+
   verify:
     name: Lint, tests e infraestructura
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,28 @@ Cuando una tarea parezca exigir algo de lo anterior: **para y pregunta**,
 proponiendo la alternativa no destructiva (archivar en vez de borrar, columna
 nueva en vez de renombrada, script con confirmación en vez de automático).
 
+### Esta regla ya no depende de que la leas
+
+Desde el 19 de agosto de 2026 la lista de arriba está implementada, no sólo
+escrita. Tres capas, y ninguna sustituye a las otras:
+
+| Capa | Qué corta | Dónde vive |
+|---|---|---|
+| **Guardia de datos** (hook `PreToolUse`) | El comando o la edición, antes de ejecutarse: volúmenes de Docker, borrado en bloque de árboles de datos, limpieza de ficheros no versionados, `push --force`, SQL destructivo por `psql`, sobrescribir un `.env`, editar una migración ya escrita | [`tools/guardia-datos.mjs`](tools/guardia-datos.mjs) + [`.claude/settings.json`](.claude/settings.json) |
+| **Pruebas** (`npm test`, y por tanto CI en cada PR) | Una migración que pierda filas o estructuras, y cualquier `DELETE`/`UPDATE` sin `WHERE` en `src/` | [`test/guardia-datos.test.js`](test/guardia-datos.test.js) |
+| **CI** | Editar o borrar una migración ya publicada en la rama base | Job «Migraciones inmutables» de `.github/workflows/ci.yml` |
+
+La guardia peca de prudente a propósito: un comando que sólo **menciona** algo
+destructivo —documentación escrita desde un heredoc, por ejemplo— también se
+corta. Cuando pase, escribe el fichero con la herramienta de edición en vez de
+por consola; es el lado bueno del error.
+
+Autorizar algo destructivo es de la persona que opera el entorno, y **por
+comando**: exporta `MOODLESHIELD_PERMITIR_DESTRUCTIVO` con un fragmento del
+comando concreto antes de abrir la sesión. Un `=1` genérico no abre nada, y una
+asignación en la propia línea tampoco: el hook no la ve, porque hereda el
+entorno de quien abrió la sesión.
+
 ## Regla 0-bis — hay una operación en marcha, y lo ya emitido no se toca
 
 **Nada de lo que diseñes puede exigir rehacer lo que ya está desplegado.** Hay
@@ -71,7 +93,7 @@ sueltos. Antes de tocar nada:
 | [`docs/README.md`](docs/README.md) | **EMPIEZA AQUÍ**: índice, estado del proyecto, hoja de ruta, limitaciones |
 | [`docs/revision-seguridad-2026-08-10.md`](docs/revision-seguridad-2026-08-10.md) | Estado de seguridad vigente: rama frente a producción, riesgos y gates de despliegue |
 | [`docs/arquitectura.md`](docs/arquitectura.md) | Vista general, árbol de medios, camino de un visionado y de una subida, modelo de datos, endpoints, modelo de seguridad |
-| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…027: por qué cada decisión y cómo revertirla |
+| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…029: por qué cada decisión y cómo revertirla |
 | [`docs/desarrollo.md`](docs/desarrollo.md) | Entorno, tests, convenciones, trampas, flujo de Git |
 | [`docs/estado-del-proyecto.md`](docs/estado-del-proyecto.md) | Auditoría histórica de la entrega del 6 de agosto; no usar como estado vigente |
 | [`docs/plan-implementacion.md`](docs/plan-implementacion.md) | Mapa de fases y dependencias |
@@ -167,6 +189,7 @@ src/queue/      cola Postgres con lease, heartbeat y reaper (vídeo y PDF)
 src/ui/         HTML sin framework + assets; render.js sustituye {{BOOTSTRAP}}
 migrations/     SQL plano, numeradas, inmutables una vez aplicadas
 tools/trace.mjs trazado forense de una filtración
+tools/guardia-datos.mjs  la Regla 0 hecha código: corta lo destructivo (hook + tests)
 test/           node:test; *.test.js sin BD, integration/*.integration.js con BD
 ```
 

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -1080,3 +1080,73 @@ es un control:
 volver a disparar `cd-test.yml` con `branches: [main]` y quitar el job
 `frontera-entornos`. La rama `test` puede quedarse donde está; no la lee nadie
 más. Conviene no hacerlo: es volver a la situación que causó el incidente.
+
+## ADR-029 · La Regla 0 se implementa: la pérdida de datos se corta antes de ocurrir, no se recuerda
+
+**Estado**: aceptada · **Fecha**: 2026-08
+
+**Contexto.** `CLAUDE.md` abre con la Regla 0 —hay producción con vídeos, PDF y
+actividades Moodle vivas— y con una lista de lo que nunca se hace. Esa lista es
+correcta y nunca ha bastado del todo, porque una regla escrita sólo protege
+mientras quien la lee la respeta y la recuerda. Basta un comando de memoria
+muscular, un agente con prisa o una receta copiada de un tutorial para perder
+material que nadie va a volver a subir: del vídeo original de un profesor no hay
+otra copia una vez borrado su árbol.
+
+Al preparar la subida a producción del 19 de agosto de 2026 se revisó qué
+impedía de verdad cada punto de esa lista. La respuesta era incómoda: casi nada.
+`src/db/guard.js` cerraba un caso concreto —que los tests truncaran una base
+viva— y CI aplicaba las migraciones sobre una base **vacía**, donde una
+migración destructiva no duele y por tanto tampoco se nota. Todo lo demás
+dependía del criterio de quien tecleaba.
+
+**Decisión.** Convertir la Regla 0 en tres controles que fallan en cerrado, cada
+uno en un momento distinto del ciclo. Ninguno sustituye a los otros: el primero
+depende de la herramienta con la que se trabaja, el segundo de que el código
+llegue a una PR, el tercero de la comparación con la rama base.
+
+1. **Guardia de datos** (`tools/guardia-datos.mjs`), enganchada como hook
+   `PreToolUse` en `.claude/settings.json`. Decide sobre la llamada a la
+   herramienta —antes de ejecutarla— y corta el borrado de volúmenes de Docker,
+   el borrado en bloque de árboles de datos, la limpieza de ficheros no
+   versionados, la reescritura de historia publicada, el SQL destructivo lanzado
+   contra la base, la sobrescritura de un fichero de secretos y la edición de una
+   migración ya escrita. La decisión es una función pura, así que el catálogo se
+   prueba sin ejecutar nada.
+2. **Pruebas** (`test/guardia-datos.test.js`), que corren en `npm test` y por
+   tanto en cada PR: ninguna migración puede llevar sentencias que pierdan filas
+   o estructuras, y ningún literal SQL de `src/` puede modificar una tabla sin
+   `WHERE`. `DROP INDEX` y `DROP CONSTRAINT` se admiten: reorganizan el esquema
+   sin perder una fila, y 002 y 016 los usan.
+3. **CI** (job «Migraciones inmutables»): una migración que ya existía en la rama
+   base no puede modificarse ni borrarse. Editarla no arregla nada donde ya
+   corrió —no vuelve a ejecutarse— y separa en silencio el esquema real del que
+   describe el repositorio.
+
+Y un cierre en la aplicación, que es donde estaba el único agujero real: borrar
+un material **colocado en una actividad viva** responde 409 `material_placed` en
+vez de destruirlo. Insertado suelto no había nada que lo impidiera
+—`resource_placement.resource_id` es un uuid sin clave ajena—, así que el
+borrado salía adelante y rompía la actividad para sus alumnos sin que Moodle
+avisara a nadie: ese callback no existe. Por el snapshot de una colección sí
+frenaba el `ON DELETE RESTRICT`, pero con un error de integridad ilegible; ahora
+las dos puertas dan el mismo 409 accionable, y archivar sigue abierto.
+
+La guardia peca de prudente: un comando que sólo **menciona** algo destructivo
+también se corta. Se acepta a conciencia. El coste de un falso positivo es
+escribir el fichero con la herramienta de edición; el de un falso negativo es
+material perdido.
+
+Autorizar sigue siendo posible, porque la Regla 0 lo contempla («sin que el
+usuario lo pida de forma explícita y para esa ejecución concreta»), pero es de
+la persona que opera el entorno y **por comando**:
+`MOODLESHIELD_PERMITIR_DESTRUCTIVO` lleva un fragmento del comando que autoriza.
+Un valor genérico no abre nada, y una asignación en la propia línea tampoco: el
+hook hereda el entorno de quien abrió la sesión, no el del comando.
+
+**Cómo revertirlo.** Quitar el bloque `hooks` de `.claude/settings.json`
+desactiva la primera capa sin tocar nada más; borrar `test/guardia-datos.test.js`
+y el job «Migraciones inmutables», las otras dos. El 409 de material colocado se
+revierte quitando la comprobación de `resource_placement` de `deleteOwnedVideo` y
+`deleteOwnedDocument`. Conviene no hacerlo: lo que queda entonces es la lista
+escrita, que es justo lo que no bastó.

--- a/src/routes/documents.js
+++ b/src/routes/documents.js
@@ -236,6 +236,15 @@ documentsRouter.delete('/:id', requireCatalogInstructor, async (req, res, next) 
         collections: result.collections.map((row) => ({ id: row.id, title: row.title }))
       })
     }
+    if (result.status === 'placed') {
+      return res.status(409).json({
+        error: `Este material está insertado en ${result.courses.length} actividad(es) de Moodle. ` +
+          'Bórralo de ellas primero, o archívalo: archivar lo retira del catálogo sin romper ' +
+          'lo que los alumnos ya tienen delante.',
+        code: 'material_placed',
+        courses: result.courses.length
+      })
+    }
     await removeMaterialFiles('pdf', id).catch((err) => {
       logger.warn({ err, documentId: id }, 'Documento borrado de DB; quedan ficheros para reconciliar')
     })

--- a/src/routes/videos.js
+++ b/src/routes/videos.js
@@ -246,6 +246,15 @@ videosRouter.delete('/:id', requireCatalogInstructor, async (req, res, next) => 
         collections: result.collections.map((row) => ({ id: row.id, title: row.title }))
       })
     }
+    if (result.status === 'placed') {
+      return res.status(409).json({
+        error: `Este material está insertado en ${result.courses.length} actividad(es) de Moodle. ` +
+          'Bórralo de ellas primero, o archívalo: archivar lo retira del catálogo sin romper ' +
+          'lo que los alumnos ya tienen delante.',
+        code: 'material_placed',
+        courses: result.courses.length
+      })
+    }
     await removeMaterialFiles('video', id).catch((err) => {
       logger.warn({ err, videoId: id }, 'Vídeo borrado de DB; quedan ficheros para reconciliar')
     })

--- a/src/services/documents.js
+++ b/src/services/documents.js
@@ -234,6 +234,20 @@ export function deleteOwnedDocument ({ documentId, platformId, ownerSub }) {
     )
     if (used.length > 0) return { status: 'referenced', collections: used, sourcePaths: [], revisions: [] }
 
+    // Igual que en vídeo: una actividad viva manda sobre el borrado (Regla 0-bis).
+    const { rows: colocado } = await client.query(
+      `SELECT DISTINCT p.context_id
+         FROM resource_placement p
+        WHERE p.revoked_at IS NULL
+          AND ((p.resource_kind = 'pdf' AND p.resource_id = $1)
+               OR EXISTS (SELECT 1 FROM resource_placement_item i
+                           WHERE i.placement_id = p.id AND i.document_id = $1))`,
+      [documentId]
+    )
+    if (colocado.length > 0) {
+      return { status: 'placed', courses: colocado.map((row) => row.context_id), sourcePaths: [], revisions: [] }
+    }
+
     const { rows: jobs } = await client.query(
       'SELECT source_path FROM pdf_job WHERE document_id = $1 FOR UPDATE',
       [documentId]

--- a/src/services/videos.js
+++ b/src/services/videos.js
@@ -286,6 +286,21 @@ export function deleteOwnedVideo ({ videoId, platformId, ownerSub }) {
     )
     if (used.length > 0) return { status: 'referenced', collections: used, sourcePaths: [], revisions: [] }
 
+    // Lo ya emitido no se toca: si hay una actividad de Moodle sirviendo esto,
+    // borrarlo la rompe para sus alumnos y no hay callback que avise a nadie.
+    const { rows: colocado } = await client.query(
+      `SELECT DISTINCT p.context_id
+         FROM resource_placement p
+        WHERE p.revoked_at IS NULL
+          AND ((p.resource_kind = 'video' AND p.resource_id = $1)
+               OR EXISTS (SELECT 1 FROM resource_placement_item i
+                           WHERE i.placement_id = p.id AND i.video_id = $1))`,
+      [videoId]
+    )
+    if (colocado.length > 0) {
+      return { status: 'placed', courses: colocado.map((row) => row.context_id), sourcePaths: [], revisions: [] }
+    }
+
     const { rows: jobs } = await client.query(
       'SELECT source_path FROM transcode_job WHERE video_id = $1 FOR UPDATE',
       [videoId]

--- a/test/guardia-datos.test.js
+++ b/test/guardia-datos.test.js
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { revisar } from '../tools/guardia-datos.mjs'
+
+const raiz = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * La Regla 0 de `CLAUDE.md` —hay producción con material real dentro— sólo
+ * protege mientras quien la lee la respeta. Estas pruebas son la parte que no
+ * depende de eso: fijan el catálogo de lo que la guardia tiene que cortar y,
+ * sobre todo, impiden que se afloje sin que nadie lo note.
+ */
+
+const DEBE_BLOQUEAR = [
+  ['docker compose down -v', 'volumenes-docker'],
+  ['docker compose -f infra/local/compose.yml down --volumes', 'volumenes-docker'],
+  ['docker volume rm moodleshield_pgdata', 'volumenes-docker'],
+  ['docker system prune -af', 'volumenes-docker'],
+  ['rm -rf infra/local/data', 'rm-datos'],
+  ['rm -rf /docker-apps/moodleshield-pro/media', 'rm-datos'],
+  ['rm -rf uploads/', 'rm-datos'],
+  ['git clean -fdx', 'git-clean'],
+  ['git push --force origin main', 'historia-publicada'],
+  ['git push --force-with-lease origin test', 'historia-publicada'],
+  ['psql -c "DROP TABLE content_collection"', 'sql-destructivo'],
+  ['psql -c "TRUNCATE video_view_event"', 'sql-destructivo'],
+  ['docker exec -i db psql -U moodleshield -c "DELETE FROM video"', 'sql-destructivo'],
+  ['dropdb moodleshield', 'sql-destructivo'],
+  ['echo "SESSION_SECRET=nuevo" > infra/prod/.env', 'secretos']
+]
+
+const DEBE_DEJAR_PASAR = [
+  'docker compose down',
+  'docker compose -f infra/local/compose.yml up -d --build',
+  'rm -rf node_modules',
+  'rm -f package-lock.json',
+  'git push -u origin fix/pruebas-pap',
+  'git clean -n',
+  'psql -c "SELECT count(*) FROM video"',
+  'docker exec -i db psql -U moodleshield -c "DELETE FROM upload_reservation WHERE expires_at < now()"',
+  'npm test',
+  'grep -rn "DELETE FROM" src/'
+]
+
+test('la guardia corta lo que destruye datos', () => {
+  for (const [comando, nombre] of DEBE_BLOQUEAR) {
+    const decision = revisar({ tool: 'Bash', input: { command: comando }, env: {} })
+    assert.equal(decision.bloqueado, true, `debería bloquear: ${comando}`)
+    assert.equal(decision.nombre, nombre, `regla equivocada para: ${comando}`)
+    assert.ok(decision.alternativa, 'bloquear sin decir por dónde ir sólo invita a buscar un rodeo')
+  }
+})
+
+/**
+ * Una guardia que bloquea de más se acaba desactivando, y entonces no protege
+ * de nada. Esta mitad es tan importante como la otra.
+ */
+test('la guardia no estorba al trabajo normal', () => {
+  for (const comando of DEBE_DEJAR_PASAR) {
+    const decision = revisar({ tool: 'Bash', input: { command: comando }, env: {} })
+    assert.equal(decision.bloqueado, false, `no debería bloquear: ${comando} (${decision.nombre})`)
+  }
+})
+
+test('una migración ya escrita no se edita; una nueva sí', () => {
+  const aplicada = { file_path: 'migrations/014_resource_placement.sql' }
+  assert.equal(revisar({ tool: 'Edit', input: aplicada, env: {} }).bloqueado, true)
+  assert.equal(revisar({ tool: 'Write', input: aplicada, env: {}, existe: () => true }).bloqueado, true)
+  assert.equal(
+    revisar({ tool: 'Write', input: { file_path: 'migrations/017_lo_que_toque.sql' }, env: {}, existe: () => false }).bloqueado,
+    false,
+    'el camino correcto —una migración nueva— tiene que quedar abierto'
+  )
+})
+
+test('los secretos y el árbol de datos no se reescriben a mano', () => {
+  for (const ruta of ['infra/prod/.env', '.env.local', 'infra/local/data/media/x.m3u8']) {
+    assert.equal(revisar({ tool: 'Write', input: { file_path: ruta }, env: {} }).bloqueado, true, ruta)
+  }
+  for (const ruta of ['infra/prod/.env.sample', 'infra/test/.env.ci', 'src/config.js']) {
+    assert.equal(revisar({ tool: 'Write', input: { file_path: ruta }, env: {} }).bloqueado, false, ruta)
+  }
+})
+
+/**
+ * La puerta de escape existe porque la Regla 0 la contempla: «sin que el usuario
+ * lo pida de forma explícita y para esa ejecución concreta». Por eso el permiso
+ * nombra el comando; un `=1` genérico no abre nada.
+ */
+test('la autorización explícita es por comando, no un interruptor', () => {
+  const comando = 'docker volume rm moodleshield_test_pgdata'
+  assert.equal(revisar({ tool: 'Bash', input: { command: comando }, env: { MOODLESHIELD_PERMITIR_DESTRUCTIVO: '1' } }).bloqueado, true)
+  assert.equal(revisar({ tool: 'Bash', input: { command: comando }, env: { MOODLESHIELD_PERMITIR_DESTRUCTIVO: comando } }).bloqueado, false)
+  assert.equal(
+    revisar({ tool: 'Bash', input: { command: 'docker volume rm moodleshield_pgdata' }, env: { MOODLESHIELD_PERMITIR_DESTRUCTIVO: comando } }).bloqueado,
+    true,
+    'autorizar el volumen de test no puede autorizar el de producción'
+  )
+})
+
+test('el hook está enchufado en los ajustes del proyecto', async () => {
+  const ajustes = JSON.parse(await readFile(path.join(raiz, '.claude/settings.json'), 'utf8'))
+  const previos = ajustes.hooks?.PreToolUse ?? []
+  const guardia = previos.find((entrada) =>
+    (entrada.hooks ?? []).some((h) => String(h.command ?? '').includes('guardia-datos.mjs')))
+  assert.ok(guardia, 'sin el hook en .claude/settings.json la guardia no corta nada')
+  for (const herramienta of ['Bash', 'Edit', 'Write']) {
+    assert.match(guardia.matcher, new RegExp(herramienta),
+      `${herramienta} puede destruir datos: tiene que pasar por la guardia`)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Lo que se despliega: ninguna migración puede perder filas
+// ---------------------------------------------------------------------------
+
+/** Quita comentarios: el «por qué» de una migración habla de borrar sin borrar. */
+function soloSql (texto) {
+  return texto.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ')
+}
+
+const PROHIBIDO_EN_MIGRACIONES = [
+  { patron: /\bdrop\s+table\b/i, que: 'DROP TABLE' },
+  { patron: /\bdrop\s+(column|schema|database)\b/i, que: 'DROP de columna, esquema o base' },
+  { patron: /\btruncate\b/i, que: 'TRUNCATE' },
+  { patron: /\bdelete\s+from\b/i, que: 'DELETE' }
+]
+
+/**
+ * Una migración destructiva pasaría hoy sin que nadie la viera: CI las aplica
+ * sobre una base vacía, donde `DROP TABLE` no duele. En producción sí.
+ *
+ * `DROP INDEX` y `DROP CONSTRAINT` se admiten a propósito: reorganizan el
+ * esquema sin perder una sola fila, y 002 y 016 los usan.
+ */
+test('ninguna migración destruye datos', async () => {
+  const dir = path.join(raiz, 'migrations')
+  for (const fichero of (await readdir(dir)).filter((f) => f.endsWith('.sql'))) {
+    const sql = soloSql(await readFile(path.join(dir, fichero), 'utf8'))
+    for (const { patron, que } of PROHIBIDO_EN_MIGRACIONES) {
+      assert.doesNotMatch(sql, patron,
+        `${fichero} lleva ${que}: una migración es aditiva. Lo que sobra se deja y se documenta.`)
+    }
+  }
+})
+
+/** Literales SQL del código: `pg` a secas, así que el SQL viaja en cadenas. */
+function literalesSql (codigo) {
+  return [...codigo.matchAll(/`([^`]*)`|'((?:[^'\\\n]|\\.)*)'|"((?:[^"\\\n]|\\.)*)"/g)]
+    .map((m) => m[1] ?? m[2] ?? m[3] ?? '')
+    .filter((texto) => /\b(delete\s+from|update\s+\w+\s+set)\b/i.test(texto))
+}
+
+async function ficherosJs (dir) {
+  const salida = []
+  for (const entrada of await readdir(dir, { withFileTypes: true })) {
+    const completa = path.join(dir, entrada.name)
+    if (entrada.isDirectory()) salida.push(...await ficherosJs(completa))
+    else if (entrada.name.endsWith('.js')) salida.push(completa)
+  }
+  return salida
+}
+
+/**
+ * Un `DELETE` o un `UPDATE` sin `WHERE` vacía una tabla entera. Con carpetas,
+ * colecciones y revisiones colgando unas de otras por clave ajena, uno solo se
+ * lleva por delante media biblioteca.
+ */
+test('ningún DELETE ni UPDATE del código va sin WHERE', async () => {
+  for (const fichero of await ficherosJs(path.join(raiz, 'src'))) {
+    for (const sql of literalesSql(await readFile(fichero, 'utf8'))) {
+      assert.match(sql, /\bwhere\b/i,
+        `${path.relative(raiz, fichero)} tiene SQL sin WHERE: ${sql.trim().slice(0, 80)}`)
+    }
+  }
+})

--- a/test/integration/resource-placement.integration.js
+++ b/test/integration/resource-placement.integration.js
@@ -5,6 +5,7 @@ import { closeDatabase, query } from '../../src/db/index.js'
 import { runMigrations } from '../../src/db/migrate.js'
 import { issueSession, verifySession } from '../../src/session.js'
 import { registerPlaybackGrant, touchPlaybackGrant } from '../../src/services/playback-grants.js'
+import { deleteOwnedVideo } from '../../src/services/videos.js'
 import {
   authorizeResourcePlacement,
   createResourcePlacements,
@@ -296,4 +297,43 @@ test('el placement sustituido deja de abrir el material que servía', async () =
     }),
     (err) => err instanceof ResourcePlacementError
   )
+})
+
+/**
+ * Regla 0-bis: lo ya emitido no se toca. Un material insertado suelto no tiene
+ * clave ajena que lo proteja —`resource_placement.resource_id` es un uuid a
+ * secas—, así que borrarlo salía adelante y dejaba la actividad rota para los
+ * alumnos, sin que Moodle avisara a nadie: no existe ese callback.
+ */
+test('borrar material que una actividad viva sirve se niega, y archivar sigue abierto', async () => {
+  await place({ id: VIDEO_B, kind: 'video', owner_sub: OWNER })
+
+  const negado = await deleteOwnedVideo({ videoId: VIDEO_B, platformId: PLATFORM_ID, ownerSub: OWNER })
+  assert.equal(negado.status, 'placed')
+  assert.deepEqual(negado.courses, ['course-1'])
+  assert.equal((await query('SELECT id FROM video WHERE id=$1', [VIDEO_B])).rowCount, 1,
+    'el vídeo tiene que seguir ahí')
+
+  // Revocada la colocación, esa actividad ya no sirve el material y el borrado
+  // vuelve a ser cosa del propietario.
+  await query("UPDATE resource_placement SET revoked_at = now(), revoked_reason = 'prueba' WHERE resource_id = $1", [VIDEO_B])
+  const borrado = await deleteOwnedVideo({ videoId: VIDEO_B, platformId: PLATFORM_ID, ownerSub: OWNER })
+  assert.equal(borrado.status, 'deleted')
+})
+
+/**
+ * El snapshot de una colección cuenta igual. El caso llega cuando el profesor
+ * quita el material de la colección DESPUÉS de insertarla: la colección ya no lo
+ * lleva —así que la comprobación de «está en una colección» no salta— pero el
+ * snapshot de la actividad sí, y los alumnos que la abrieron lo tienen delante.
+ * Antes eso terminaba en el `ON DELETE RESTRICT` de `resource_placement_item`:
+ * un 500 con el texto crudo de Postgres.
+ */
+test('el material que entró por el snapshot de una colección tampoco se borra', async () => {
+  await place({ id: COLLECTION_ID, kind: 'collection', owner_sub: OWNER })
+  await query('DELETE FROM content_collection_item WHERE collection_id = $1', [COLLECTION_ID])
+
+  const negado = await deleteOwnedVideo({ videoId: VIDEO_A, platformId: PLATFORM_ID, ownerSub: OWNER })
+  assert.equal(negado.status, 'placed')
+  assert.deepEqual(negado.courses, ['course-1'])
 })

--- a/tools/guardia-datos.mjs
+++ b/tools/guardia-datos.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Guardia de datos: convierte la Regla 0 en algo que no depende de que nadie se
+ * acuerde de ella.
+ *
+ * Hay una instalación en producción con vídeos, PDF y actividades Moodle vivas.
+ * `CLAUDE.md` lo dice desde la primera línea, pero una regla escrita sólo
+ * protege mientras quien lee la respeta: basta un agente con prisa, un comando
+ * copiado de un tutorial o un `docker compose down -v` de memoria muscular para
+ * que se pierda material que nadie va a volver a subir.
+ *
+ * Este módulo decide, sobre la llamada a una herramienta, si lo que se va a
+ * hacer puede destruir datos. Se usa desde dos sitios:
+ *
+ *   - como hook `PreToolUse` de Claude Code (`.claude/settings.json`), que corta
+ *     la ejecución antes de que ocurra;
+ *   - desde `test/guardia-datos.test.js`, que fija el catálogo de lo prohibido
+ *     para que nadie lo afloje sin querer.
+ *
+ * La decisión es una función pura para poder probarla sin ejecutar nada.
+ *
+ * Puerta de escape, y sólo una: la persona que lanza la sesión exporta
+ * `MOODLESHIELD_PERMITIR_DESTRUCTIVO` con un fragmento del comando concreto que
+ * autoriza. No vale como interruptor general —el valor tiene que aparecer en el
+ * comando— y no puede ponerlo el agente desde dentro: una asignación en la
+ * propia línea (`VAR=1 rm -rf …`) no llega al proceso del hook, que hereda el
+ * entorno de quien abrió la sesión. Es la traducción literal de «sin que el
+ * usuario lo pida de forma explícita y para esa ejecución concreta».
+ */
+
+import { existsSync } from 'node:fs'
+
+const DIRECTORIOS_DE_DATOS = /(^|[\s'"=/])(data|media|uploads|pgdata|\.staging|originals)([/\s'"]|$)/i
+
+/** Rutas cuyo borrado es siempre pérdida de material, estén donde estén. */
+const RUTAS_VIVAS = [
+  /infra\/(local|test|prod)\/data/i,
+  /docker-apps\/moodleshield/i,
+  /\/(media|uploads|pgdata)(\/|$)/i
+]
+
+const SQL_DESTRUCTIVO = [
+  { patron: /\bdrop\s+(table|column|schema|database|type)\b/i, que: 'DROP de una tabla, columna, esquema o base' },
+  { patron: /\btruncate\b/i, que: 'TRUNCATE' },
+  { patron: /\bdelete\s+from\s+\S+(?!.*\bwhere\b)/is, que: 'DELETE sin WHERE' },
+  { patron: /\bupdate\s+\S+\s+set\b(?!.*\bwhere\b)/is, que: 'UPDATE sin WHERE' }
+]
+
+const REGLAS_BASH = [
+  {
+    nombre: 'volumenes-docker',
+    // `docker compose -f … down --volumes` mete opciones entre medias: el patrón
+    // tiene que llegar hasta el final del comando, no sólo a la palabra siguiente.
+    patron: /docker\s+(compose\b[^;&|]*\bdown\b[^;&|]*\s(-v\b|--volumes\b)|volume\s+(rm|prune)\b|system\s+prune\b)/i,
+    motivo: 'borra los volúmenes de Docker, que es donde viven Postgres, los medios y las subidas',
+    alternativa: 'Para parar el stack sin tocar datos: `docker compose down` (sin `-v`). ' +
+      'Si de verdad hay que borrar un volumen, hazlo tú a mano tras comprobar qué contiene.'
+  },
+  {
+    nombre: 'rm-datos',
+    patron: /(^|[\s;&|])rm\s+(-[a-z]*[rf][a-z]*\s+)+/i,
+    condicion: (comando) => RUTAS_VIVAS.some((r) => r.test(comando)) || DIRECTORIOS_DE_DATOS.test(quitarOpciones(comando)),
+    motivo: 'borra en bloque un árbol que puede contener material publicado',
+    alternativa: 'Archivar en vez de borrar. Si hay que limpiar de verdad, di qué rutas exactas ' +
+      'y cuántos ficheros hay antes de tocarlas.'
+  },
+  {
+    nombre: 'git-clean',
+    patron: /git\s+clean\b[^;&|]*-[a-z]*[dx]/i,
+    motivo: 'borra ficheros no versionados, y `infra/local/data` está fuera de git a propósito',
+    alternativa: 'Limpia lo que sobre nombrándolo, o usa `git clean -n` para ver qué se llevaría.'
+  },
+  {
+    nombre: 'historia-publicada',
+    patron: /git\s+push\b[^;&|]*(--force\b|--force-with-lease\b|(^|\s)-f(\s|$))/i,
+    motivo: 'reescribe historia ya publicada, y de ella cuelgan los despliegues (`deploy(test|prod)`)',
+    alternativa: 'Un commit nuevo encima. Si de verdad hay que reescribir, lo decide y lo hace una persona.'
+  },
+  {
+    nombre: 'sql-destructivo',
+    patron: /(psql|pg_dump|pg_restore|dropdb|docker\s+exec[^;&|]*psql)/i,
+    condicion: (comando) => /dropdb\b/i.test(comando) || SQL_DESTRUCTIVO.some(({ patron }) => patron.test(comando)),
+    motivo: 'ejecuta SQL que pierde filas o estructuras contra una base que puede ser la viva',
+    alternativa: 'Una migración nueva, numerada y aditiva. Una columna que sobra se documenta, no se borra.'
+  },
+  {
+    nombre: 'secretos',
+    patron: /(^|[\s;&|])(cat|echo|printf|tee)\b[^;&|]*>\s*[^\s;&|]*\.env(\.local)?(\s|$)/i,
+    motivo: 'sobrescribe un fichero de secretos: rotarlos invalida sesiones, enlaces firmados y la firma ' +
+      'de las actividades ya insertadas',
+    alternativa: 'Añadir claves al bloque existente (`>>` sobre una copia revisada), nunca regenerarlo entero.'
+  }
+]
+
+/** Quita las opciones (`-rf`, `--force`) para que `-r` no cuente como ruta `r`. */
+function quitarOpciones (comando) {
+  return comando.replace(/(^|\s)-{1,2}[a-z-]+/gi, ' ')
+}
+
+/** Ficheros que, una vez escritos, son inmutables por contrato. */
+function motivoPorRuta (ruta) {
+  if (/(^|\/)migrations\/.+\.sql$/.test(ruta)) {
+    return {
+      nombre: 'migracion-aplicada',
+      motivo: 'reescribe una migración ya publicada, y son inmutables por contrato: en un entorno ' +
+        'donde ya corrió no vuelve a ejecutarse, así que el esquema se separa en silencio del repositorio',
+      alternativa: 'Una migración NUEVA, numerada, aditiva y reejecutable.'
+    }
+  }
+  if (/(^|\/)\.env(\.local)?$/.test(ruta)) {
+    return {
+      nombre: 'secretos',
+      motivo: 'reescribe un fichero de secretos, y rotarlos invalida trazas, enlaces firmados, sesiones ' +
+        'y la firma de las actividades ya insertadas',
+      alternativa: 'Añadir claves al bloque existente; el que hay no se regenera.'
+    }
+  }
+  if (RUTAS_VIVAS.some((r) => r.test(ruta))) {
+    return {
+      nombre: 'datos-vivos',
+      motivo: 'escribe dentro del árbol de datos de un entorno, donde vive el material y no el código',
+      alternativa: 'El material se toca por la aplicación, no a mano.'
+    }
+  }
+  return null
+}
+
+/**
+ * Decide si una llamada a herramienta puede destruir datos.
+ *
+ * @param {object} llamada
+ * @param {string} llamada.tool           Nombre de la herramienta (`Bash`, `Edit`, `Write`…).
+ * @param {object} llamada.input          Su entrada tal cual.
+ * @param {object} [llamada.env]          Entorno, para la autorización explícita.
+ * @param {(ruta: string) => boolean} [llamada.existe]  Si un fichero ya existe.
+ * @returns {{bloqueado: boolean, nombre?: string, motivo?: string, alternativa?: string}}
+ */
+export function revisar ({ tool, input = {}, env = process.env, existe = () => true } = {}) {
+  const permitido = String(env.MOODLESHIELD_PERMITIR_DESTRUCTIVO ?? '').trim()
+
+  if (tool === 'Bash') {
+    const comando = String(input.command ?? '')
+    for (const regla of REGLAS_BASH) {
+      if (!regla.patron.test(comando)) continue
+      if (regla.condicion && !regla.condicion(comando)) continue
+      if (permitido && comando.includes(permitido)) return { bloqueado: false }
+      return { bloqueado: true, nombre: regla.nombre, motivo: regla.motivo, alternativa: regla.alternativa }
+    }
+    return { bloqueado: false }
+  }
+
+  if (tool === 'Edit' || tool === 'Write' || tool === 'NotebookEdit' || tool === 'MultiEdit') {
+    const ruta = String(input.file_path ?? input.notebook_path ?? '')
+    if (!ruta) return { bloqueado: false }
+    const hallazgo = motivoPorRuta(ruta)
+    if (!hallazgo) return { bloqueado: false }
+    // Una migración que todavía no existe es una migración nueva: eso es
+    // justamente lo que hay que hacer.
+    if (hallazgo.nombre === 'migracion-aplicada' && tool === 'Write' && !existe(ruta)) {
+      return { bloqueado: false }
+    }
+    if (permitido && ruta.includes(permitido)) return { bloqueado: false }
+    return { bloqueado: true, ...hallazgo }
+  }
+
+  return { bloqueado: false }
+}
+
+export function mensaje (decision, tool) {
+  return [
+    `⛔ Bloqueado por la guardia de datos (${decision.nombre}).`,
+    '',
+    `Esta llamada a ${tool} ${decision.motivo}.`,
+    '',
+    `Alternativa: ${decision.alternativa}`,
+    '',
+    'Hay una operación en marcha con material real dentro (Regla 0 de CLAUDE.md). Si esto',
+    'hace falta de verdad, explícalo y que lo autorice y lo ejecute la persona que opera el',
+    'entorno; no lo intentes por otro camino.'
+  ].join('\n')
+}
+
+/* c8 ignore start -- el modo hook se prueba a través de `revisar` */
+async function main () {
+  const trozos = []
+  for await (const trozo of process.stdin) trozos.push(trozo)
+  let evento = {}
+  try {
+    evento = JSON.parse(Buffer.concat(trozos).toString('utf8') || '{}')
+  } catch {
+    // Un hook que no entiende su entrada no puede bloquear el trabajo: deja pasar.
+    process.exit(0)
+  }
+  const tool = evento.tool_name ?? evento.tool ?? ''
+  const decision = revisar({ tool, input: evento.tool_input ?? evento.input ?? {}, existe: existeEnDisco })
+  if (!decision.bloqueado) process.exit(0)
+  process.stderr.write(`${mensaje(decision, tool)}\n`)
+  process.exit(2)
+}
+
+function existeEnDisco (ruta) {
+  try {
+    return existsSync(ruta)
+  } catch {
+    // Ante la duda, se trata como existente: bloquear de más se arregla
+    // hablando; bloquear de menos, no.
+    return true
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) await main()
+/* c8 ignore stop */


### PR DESCRIPTION
Antes de subir a producción se revisó **qué impedía de verdad** cada punto de la
Regla 0 de `CLAUDE.md`. Respuesta incómoda: casi nada. `src/db/guard.js` cerraba
un caso concreto —que los tests truncaran una base viva— y CI aplica las
migraciones sobre una base **vacía**, donde una migración destructiva no duele y
por tanto tampoco se nota. Todo lo demás dependía del criterio de quien tecleaba.

## Tres capas que fallan en cerrado

| Capa | Qué corta | Cuándo |
|---|---|---|
| `tools/guardia-datos.mjs` (hook `PreToolUse`) | volúmenes de Docker, borrado en bloque de árboles de datos, limpieza de no versionados, historia publicada, SQL destructivo contra la base, sobrescritura de secretos, edición de una migración ya escrita | antes de ejecutar |
| `test/guardia-datos.test.js` | migraciones que pierden filas o estructuras; SQL de `src/` que modifica sin `WHERE` | `npm test`, en cada PR |
| Job «Migraciones inmutables» | editar o borrar una migración que ya existía en la rama base | CI |

`DROP INDEX` y `DROP CONSTRAINT` se admiten: reorganizan el esquema sin perder
una fila, y 002 y 016 los usan.

La guardia **peca de prudente**: un comando que sólo *menciona* algo destructivo
también se corta (escribiendo esta misma PR bloqueó dos veces). Se acepta a
conciencia: el coste de un falso positivo es escribir el fichero con la
herramienta de edición; el de un falso negativo, material perdido.

Autorizar sigue siendo posible —la Regla 0 lo contempla— pero es de quien opera
el entorno y **por comando**: `MOODLESHIELD_PERMITIR_DESTRUCTIVO` lleva un
fragmento del comando concreto. Un valor genérico no abre nada, y una asignación
en la propia línea tampoco: el hook hereda el entorno de quien abrió la sesión.

## El agujero real de la aplicación

Borrar material **colocado en una actividad viva** ya no destruye nada: 409
`material_placed`. Insertado suelto no había nada que lo impidiera
(`resource_placement.resource_id` es un uuid sin clave ajena), así que el borrado
salía adelante y rompía la actividad para sus alumnos sin que Moodle avisara a
nadie: ese callback no existe. Por el snapshot de una colección sí frenaba el
`ON DELETE RESTRICT`, pero con un error de integridad ilegible. Ahora las dos
puertas dan el mismo 409 accionable, y **archivar sigue abierto**.

## Compatibilidad

Sin cambios de esquema. Nada de lo ya emitido se toca: lo único que cambia de
comportamiento es que se **niegan** borrados que hasta ahora rompían actividades
en uso. Las colecciones ya eran seguras (la API las archiva, nunca las borra).

## Comprobado

`npm run lint`, `npm test` (373) y `npm run test:integration` (151) en verde, con
ocho pruebas nuevas de la guardia y dos de integración para el borrado de
material colocado. El hook verificado de punta a punta: sale 0 con una migración
nueva y 2 con la edición de una ya aplicada.

Detalle en ADR-029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt