### PR TITLE
fix(visor): la marca del PDF deja de estorbar la lectura

### DIFF
--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -1154,6 +1154,10 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
  * compresión de una cámara de móvil se la puede comer, y por encima de .18
  * empieza a estorbar sobre texto pequeño.
  *
+ * Se sirve en el suelo de esa banda: con .13 los apuntes de texto denso se leían
+ * peor de lo aceptable en pantalla. Bajar más exige salir de la banda, y eso ya
+ * no es un retoque de CSS sino renunciar a que la marca sobreviva a una foto.
+ *
  * Negro a baja opacidad en vez de un gris fijo: así el tono lo pone la propia
  * página y la marca funciona igual sobre blanco que sobre un PDF de fondo claro
  * con color.
@@ -1165,7 +1169,7 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
   width: 100%;
   height: 100%;
   color: #000;
-  opacity: var(--pdf-mark-alpha, .13);
+  opacity: var(--pdf-mark-alpha, .10);
   pointer-events: none;
   user-select: none;
 }
@@ -1174,9 +1178,10 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
   letter-spacing: .08em;
   text-transform: uppercase;
 }
-/* Si el usuario pide más contraste, la marca no debe ser la que se lo quite. */
+/* Si el usuario pide más contraste, la marca no debe ser la que se lo quite: por
+   debajo del suelo de la banda, asumiendo que ahí ya puede no salir en la foto. */
 @media (prefers-contrast: more) {
-  .pdf-page-mark { opacity: .09; }
+  .pdf-page-mark { opacity: .07; }
 }
 .pdf-page-legal {
   position: absolute;
@@ -1193,7 +1198,13 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
   white-space: nowrap;
   opacity: .9;
 }
-.pdf-watermark { opacity: .32; }
+/*
+ * La etiqueta flotante hereda de .watermark el blanco con sombra dura, que está
+ * pensado para leerse sobre vídeo. Sobre una hoja blanca lo que se ve es la
+ * sombra, y cae justo encima de un renglón: al .32 del vídeo tapaba la línea.
+ * Aquí basta con insinuarla, porque debajo ya está la marca repetida.
+ */
+.pdf-watermark { opacity: .18; }
 
 /* ---- Móvil ---- */
 @media (max-width: 720px) {


### PR DESCRIPTION
El DNI de la marca de agua se veía demasiado oscuro sobre la hoja y competía con
el texto del documento. Son **dos** capas superpuestas, y las dos aportaban:

| Capa | Antes | Ahora |
|---|---|---|
| Fondo repetido en diagonal (`--pdf-mark-alpha`) | `.13` | `.10` |
| Etiqueta flotante «DNI · Nombre» (`.pdf-watermark`) | `.32` | `.18` |
| Fondo con `prefers-contrast: more` | `.09` | `.07` |

La etiqueta flotante era la que más molestaba y no se veía en el CSS: hereda de
`.watermark` el blanco con sombra dura, pensado para leerse sobre un vídeo negro.
Sobre una hoja blanca el blanco desaparece y **lo que se ve es la sombra**, justo
encima de un renglón de texto.

El fondo repetido baja al suelo de la banda calibrada (`.10`), no por debajo: ahí
sigue sobreviviendo a la compresión de una foto de móvil, que es lo único para lo
que sirve esta capa. Bajar más exigiría salir de la banda, y eso lo vigila
`test/pdf-mark.test.js` a propósito, para que no sea un retoque suelto de CSS.

**Qué NO cambia:** el sello de la descarga (ADR-017) y la marca forense A/B del
vídeo son capas distintas y siguen igual. Esto no altera lo que cada una permite
atribuir: el fondo del visor sirve para una foto del monitor, nunca para una
filtración del fichero.

Sólo CSS. No toca material, colecciones ni nada ya desplegado en Moodle.

`npm run lint` y `npm test` (376 · 367 pass · 0 fail) en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt
