### PR TITLE
feat(compartido): quien usa un material puede corregirlo, sin duplicarlo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ sueltos. Antes de tocar nada:
 | [`docs/README.md`](docs/README.md) | **EMPIEZA AQUÍ**: índice, estado del proyecto, hoja de ruta, limitaciones |
 | [`docs/revision-seguridad-2026-08-10.md`](docs/revision-seguridad-2026-08-10.md) | Estado de seguridad vigente: rama frente a producción, riesgos y gates de despliegue |
 | [`docs/arquitectura.md`](docs/arquitectura.md) | Vista general, árbol de medios, camino de un visionado y de una subida, modelo de datos, endpoints, modelo de seguridad |
-| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…027: por qué cada decisión y cómo revertirla |
+| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…029: por qué cada decisión y cómo revertirla |
 | [`docs/desarrollo.md`](docs/desarrollo.md) | Entorno, tests, convenciones, trampas, flujo de Git |
 | [`docs/estado-del-proyecto.md`](docs/estado-del-proyecto.md) | Auditoría histórica de la entrega del 6 de agosto; no usar como estado vigente |
 | [`docs/plan-implementacion.md`](docs/plan-implementacion.md) | Mapa de fases y dependencias |
@@ -146,7 +146,10 @@ la biblioteca por carpetas, con buscador global.
   colección (ADR-018), y el material **desplegado en el curso** desde el que
   entra ese profesor (ADR-023). La segunda no sale del UUID sino de una fila de
   `resource_placement`, así que revocarla la cierra y T24 sigue en pie.
-  `platform_id` no tiene ninguna.
+  `platform_id` no tiene ninguna. Al otro lado de esas puertas se **trabaja**:
+  ver, insertar, editar metadatos y **subir una versión corregida y publicarla**
+  (ADR-029). Lo que no se deshace —archivar, borrar, purgar, mover de carpeta—
+  se queda con el autor, y `owner_sub` no se mueve nunca.
 - **La autorización va en la sesión, no en el UUID.** Un token de un recurso no
   abre otro. El helper es `authorizeResource(session, kind, id)`.
 - **Importar un fichero que ya existe es una revisión, no un duplicado**

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | Documento | Qué resuelve |
 |---|---|
 | [`arquitectura.md`](arquitectura.md) | Vista general, árbol de medios, el camino de un visionado y el de una subida, modelo de datos, tabla de endpoints, modelo de seguridad capa por capa |
-| [`decisiones.md`](decisiones.md) | ADR-001…028. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
+| [`decisiones.md`](decisiones.md) | ADR-001…029. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
 | [`revision-seguridad-2026-08-10.md`](revision-seguridad-2026-08-10.md) | **Estado de seguridad actual**: qué está sólo en rama, qué consta en producción, hallazgos nuevos y gates de despliegue |
 | [`auditoria-seguridad-contenido-y-plan.md`](auditoria-seguridad-contenido-y-plan.md) | **Auditoría de seguridad del contenido**: modelo de amenaza, 16 hallazgos priorizados, arquitectura objetivo y plan por fases |
 | [`auditoria-seguridad.md`](auditoria-seguridad.md) | **Segunda auditoría (V-01…V-37)** y, en su [§8](auditoria-seguridad.md#8-notas-de-implementación--claude-fable-5), el registro de qué se implementó, qué se difirió y por qué en las dos iteraciones de endurecimiento |
@@ -66,6 +66,12 @@ la misma instancia Moodle ([ADR-018](decisiones.md)), **inventario de contenido 
 en la consola de administración, e **IP real del alumno tras un CDN**
 ([ADR-019](decisiones.md)) — hasta entonces todos los visionados quedaban registrados con
 la IP del borde de Cloudflare, que es justo el dato que el trazado necesita preciso.
+
+Compartir dejó además de ser sólo de lectura: el profesor que **usa** un material
+compartido puede subir la versión corregida y publicarla ([ADR-029](decisiones.md)), y la
+corrección llega sola a las actividades y colecciones que ya lo enlazan, porque el UUID no
+se mueve. El historial guarda quién subió cada versión y volver a la anterior es un clic;
+lo irreversible —archivar, borrar, purgar— sigue siendo del autor.
 
 Y, más reciente todavía, la **importación de carpetas completas**: el profesor elige una
 carpeta de su ordenador y se sube respetando la estructura interna, omitiendo ocultos y

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -252,7 +252,8 @@ catalog_folder           carpeta personal por (platform_id, owner_sub); anidable
                          is_public la comparte con el resto de la instancia
 catalog_folder_shared    VISTA: qué carpetas están compartidas, herencia incluida
 video                    identidad lógica, propietario, carpeta, revisión activa
-video_revision           fichero físico: estado, duración, segmentos, patrón
+video_revision           fichero físico: estado, duración, segmentos, patrón,
+                         y quién la subió (puede no ser el dueño del material)
 pdf_document             identidad lógica de un PDF
 pdf_revision             fichero físico: páginas, hash
 content_collection       colección propia, archivable
@@ -376,15 +377,25 @@ platform_id  ── frontera dura. Compartir NUNCA cruza instancias Moodle
 owner_sub    ── frontera con una puerta: is_public en carpeta o colección
 ```
 
-Compartir da acceso de **trabajo**, no de propiedad:
+Compartir da acceso de **trabajo**, no de propiedad. La línea no separa mirar de
+tocar: separa lo que se puede deshacer de lo que no ([ADR-029](decisiones.md)).
 
-| Cualquier profesor de la instancia | Sólo el autor |
+| Cualquier profesor que lo vea | Sólo el autor |
 |---|---|
 | Ver, abrir e insertar en su curso | Publicar y despublicar |
-| Editar título y descripción | Archivar, borrar y purgar revisiones |
-| Componer y reordenar una colección compartida | Subir una versión nueva |
-| Renombrar la carpeta | Mover de carpeta y borrar la carpeta |
-| Duplicar una colección en su biblioteca | |
+| Editar título y descripción | Archivar, restaurar y borrar |
+| **Subir una versión corregida** | Purgar revisiones y retenerlas para una investigación |
+| **Publicar una versión y volver a una anterior** | Mover de carpeta y borrar la carpeta |
+| Descartar la candidata que subió él | Descartar cualquier candidata |
+| Componer, reordenar y duplicar una colección compartida | |
+| Renombrar la carpeta | |
+
+Corregir el fichero de otro es reversible y queda firmado: la versión anterior se
+queda `retired` con sus artefactos, el historial dice quién subió cada una y
+volver atrás es un clic. Lo que cambia con la corrección lo hace **solo**, sin
+reinsertar nada: las actividades Moodle, las colecciones y la biblioteca de los
+demás apuntan al mismo UUID. Lo irreversible —archivar, purgar, borrar— se queda
+con el autor, y `owner_sub` no se mueve nunca.
 
 Las FK compuestas `(folder_id, platform_id, owner_sub)` siguen exigiendo que una
 carpeta contenga sólo material de su autor: se ve la biblioteca del otro, no se

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -511,6 +511,11 @@ material de su autor. De ahí la única limitación visible —se ve la bibliote
 del otro, no se escribe dentro— que la interfaz explica en vez de dejar que
 falle: subir o mover algo a una carpeta ajena responde 409 con el motivo.
 
+**Actualización (20 de agosto de 2026).** ADR-029 mueve **subir una versión
+nueva** a la columna de la izquierda: quien usa el material lo corrige donde
+está. La tabla de arriba se lee con esa línea cambiada de sitio; el resto sigue
+igual.
+
 **Consecuencias.** Todo lo publicado antes de la migración sigue privado:
 `is_public` nace en `false`. La biblioteca de un profesor puede crecer con
 material que no es suyo, así que las tarjetas dicen de quién es y esconden las
@@ -1089,3 +1094,89 @@ manual del pipeline vive en [`.github/README.md`](../.github/README.md).
 volver a disparar `cd-test.yml` con `branches: [main]` y quitar el job
 `frontera-entornos`. La rama `test` puede quedarse donde está; no la lee nadie
 más. Conviene no hacerlo: es volver a la situación que causó el incidente.
+
+---
+
+## ADR-029 · Corregir un material compartido es acceso de trabajo; lo irreversible sigue siendo del autor
+
+**Estado**: aceptada · **Fecha**: 2026-08 · Amplía a ADR-018
+
+**Contexto.** ADR-018 dejó «subir una versión nueva» en la columna del autor, con
+un argumento que parecía sólido: cambia lo que ya están viendo los alumnos de
+otro profesor. El caso real lo desmiente. Quien detecta el error de un vídeo casi
+nunca es quien lo subió, sino quien lo está usando en clase, y con la regla
+anterior sólo le quedaban dos salidas, las dos malas:
+
+- **Pedírselo al autor** y esperar. Mientras tanto sus alumnos siguen viendo el
+  error, y el autor puede estar de baja, de vacaciones o haberse ido del centro.
+- **Subir su propia copia**, que es un UUID nuevo: otra transcodificación, otro
+  fichero en disco y —lo que de verdad importa— las actividades Moodle que ya
+  existen siguen apuntando al vídeo equivocado. Es exactamente el duplicado que
+  ADR-025 y T21 se inventaron para evitar.
+
+**Decisión.** La frontera de lo compartido deja de separar «mirar» de «tocar» y
+pasa a separar **lo reversible y firmado** de **lo que no tiene vuelta**:
+
+| Cualquier profesor que lo vea | Sólo el autor |
+|---|---|
+| Ver, abrir e insertar en su curso | Publicar y despublicar |
+| Editar título y descripción | Archivar, restaurar y borrar |
+| **Subir una versión corregida** | Purgar revisiones y retenerlas para una investigación |
+| **Publicar una versión y volver a una anterior** | Mover de carpeta y borrar la carpeta |
+| Descartar la candidata **que subió él** | Descartar cualquier candidata |
+| Componer, reordenar y duplicar una colección compartida | Renombrar sigue siendo de los dos |
+
+La puerta es exactamente la misma que ya abría editar metadatos: `visibleClause`
+de [`sharing.js`](../src/services/sharing.js) —propio, carpeta o colección
+compartida, o material desplegado en el curso desde el que entra (ADR-023)—. No
+se inventa ningún camino nuevo: un UUID que no se ve sigue respondiendo 404.
+
+Tres cierres van con la decisión, porque sin ellos sería sólo aflojar una regla:
+
+1. **Cada versión dice quién la subió.** `created_by_sub` ya se guardaba; la
+   migración `017` añade `created_by_name` para que el historial sea legible por
+   una persona y no un `sub` de LTI. La interfaz lo enseña en cada línea.
+2. **Se avisa antes, no después.** El diálogo de versiones de un material ajeno
+   dice de quién es y que publicar cambia lo que ven sus alumnos y los de
+   cualquier otro curso donde esté insertado.
+3. **Descartar la candidata de otro, no.** El autor puede con cualquiera —el
+   índice de candidata única sólo admite una viva, y si no pudiera, una subida
+   ajena a medias le bloquearía la suya—; los demás, sólo con la que subieron.
+   Cancelar el trabajo de otro no es corregir un material.
+
+**Razones.** Lo que hace revisable esta operación es que **no destruye nada**: la
+versión anterior queda `retired` con sus artefactos en disco, sale en el
+historial y cualquiera de los dos puede volver a ella con un clic. Frente a eso,
+archivar, purgar o borrar sí son puertas de un solo sentido, y ahí la propiedad
+sigue mandando.
+
+Y lo que se gana es justo el valor entero del versionado: la corrección llega
+**sola** a todo lo que ya enlaza ese UUID —las actividades Moodle insertadas, las
+colecciones que lo contienen, la biblioteca de los demás profesores— sin
+reinsertar nada en Moodle y sin que nadie tenga que enterarse de nada.
+
+**Consecuencias.**
+
+- Un profesor con acceso puede cambiar lo que ven los alumnos de otro. Es la
+  contrapartida deliberada, y por eso el historial firma quién y el rollback está
+  a un clic. Quien no quiera esto tiene la herramienta de siempre: dejar de
+  compartir la carpeta.
+- **No hay aviso al autor.** No existe canal de notificación en la herramienta;
+  el cambio se ve al abrir «Versiones…». Es una limitación conocida, no un
+  descuido.
+- `owner_sub` **no cambia**: el material sigue siendo de su autor, la firma T24
+  (`custom.resourcesig`) sigue calculándose igual y no hay ni una actividad que
+  reinsertar.
+- El almacenamiento de la versión nueva cuenta en la cuota del **autor**, porque
+  la revisión cuelga de su material; la reserva de la subida, en la de quien
+  sube. Es coherente con quién posee el contenido.
+- **Importar una carpeta sigue sin tocar material ajeno**:
+  `findOwnMaterialByTitle` filtra estrictamente por `owner_sub`, para que una
+  reimportación masiva no reescriba el material de otro por coincidir el título.
+  Corregir es un acto explícito sobre un material concreto.
+
+**Cómo revertirlo.** Devolver `createVideoRevisionAndJob`,
+`createDocumentRevisionAndJob`, `activateRevision` y `discardRevision` a
+`owner_sub = $3`, y quitar «Versiones…» del menú de las tarjetas compartidas en
+`catalog.js`. La columna `created_by_name` puede quedarse: es auditoría y no
+estorba a nadie.

--- a/migrations/017_revision_autor.sql
+++ b/migrations/017_revision_autor.sql
@@ -1,0 +1,17 @@
+-- Quién subió cada versión, con un nombre que se le pueda enseñar a alguien.
+--
+-- Desde ADR-029 un profesor puede subir una versión de material COMPARTIDO por
+-- otro. La fila de la revisión ya guardaba `created_by_sub`, pero un `sub` de
+-- LTI no es legible: sin un nombre al lado, el historial de un material que han
+-- tocado dos personas no dice quién cambió qué, que es justo lo que hay que
+-- poder mirar cuando alguien pregunta por qué su vídeo ya no es el que subió.
+--
+-- Se guarda el nombre del momento de la subida y no una referencia a la
+-- persona: es un dato de auditoría y debe sobrevivir a que cambie de nombre o
+-- deje la instancia. Queda nulo en todo lo anterior a esta migración, y la
+-- interfaz lo trata como «sin nombre», no como un hueco que rellenar.
+--
+-- Aditiva y reejecutable: no toca ni una fila.
+
+ALTER TABLE video_revision ADD COLUMN IF NOT EXISTS created_by_name text;
+ALTER TABLE pdf_revision   ADD COLUMN IF NOT EXISTS created_by_name text;

--- a/src/routes/documents.js
+++ b/src/routes/documents.js
@@ -30,7 +30,7 @@ import {
 import { receiveDocumentUpload } from '../media/upload.js'
 import { parseRangeHeader } from '../media/range.js'
 import { stampPdfForViewer } from '../media/pdf-stamp.js'
-import { displayOwnerName } from '../services/sharing.js'
+import { displayOwnerName, getVisibleMaterial } from '../services/sharing.js'
 import {
   releaseUploadReservation,
   reserveUpload,
@@ -140,8 +140,15 @@ documentsRouter.post('/:id/revisions', requireCatalogInstructor, async (req, res
   const reservationId = randomUUID()
   let destination = null
   try {
-    const owned = await getDocumentForOwner(documentId, req.session.platformId, req.session.sub)
-    if (!owned) return res.status(404).json({ error: 'Documento no encontrado' })
+    // Mismo criterio que en vídeo (ADR-029): quien ve el PDF puede corregirlo.
+    const visible = await getVisibleMaterial({
+      kind: 'pdf',
+      id: documentId,
+      platformId: req.session.platformId,
+      ownerSub: req.session.sub,
+      contextId: req.session.contextId
+    })
+    if (!visible) return res.status(404).json({ error: 'Documento no encontrado' })
 
     await reserveUpload({
       id: reservationId,
@@ -158,6 +165,8 @@ documentsRouter.post('/:id/revisions', requireCatalogInstructor, async (req, res
       documentId,
       platformId: req.session.platformId,
       ownerSub: req.session.sub,
+      contextId: req.session.contextId,
+      createdByName: displayOwnerName(req.session),
       sourcePath: upload.destination,
       sizeBytes: upload.size,
       sha256: upload.sha256,

--- a/src/routes/materials.js
+++ b/src/routes/materials.js
@@ -1,7 +1,8 @@
 import { Router } from 'express'
 import { requireCatalogInstructor } from './auth.js'
 import { assertUuid } from '../media/storage.js'
-import { getOwnedMaterial, listMaterials } from '../services/materials.js'
+import { listMaterials } from '../services/materials.js'
+import { getVisibleMaterial } from '../services/sharing.js'
 import {
   activateRevision,
   archiveMaterial,
@@ -49,18 +50,29 @@ materialsRouter.get('/', requireCatalogInstructor, async (req, res, next) => {
   }
 })
 
+/**
+ * Historial de versiones. Lo ve quien ve el material —también el compartido de
+ * otro profesor (ADR-029)—, porque sin él no se puede publicar ni volver atrás.
+ *
+ * `owned` y `mine` son lo que la interfaz necesita para no ofrecer lo que el
+ * servidor va a rechazar: descartar una candidata ajena. El `sub` de quien la
+ * subió sólo viaja para el autor del material; a los demás les llega el nombre,
+ * que es lo que hay que leer, y no un identificador de otra persona.
+ */
 materialsRouter.get('/:kind/:id/revisions', requireCatalogInstructor, async (req, res, next) => {
   try {
     const kind = assertKind(req.params.kind)
     const id = assertUuid(req.params.id, 'Identificador de material')
-    const material = await getOwnedMaterial({
+    const material = await getVisibleMaterial({
       kind,
       id,
       platformId: req.session.platformId,
-      ownerSub: req.session.sub
+      ownerSub: req.session.sub,
+      contextId: req.session.contextId
     })
     if (!material) return res.status(404).json({ error: 'Material no encontrado' })
 
+    const owned = material.owner_sub === req.session.sub
     const revisions = await listRevisions({ kind, materialId: id })
     const candidate = await getCandidateRevision({ kind, materialId: id })
     res.json({
@@ -68,7 +80,14 @@ materialsRouter.get('/:kind/:id/revisions', requireCatalogInstructor, async (req
       candidateRevisionId: candidate && candidate.id !== material.active_revision_id
         ? candidate.id
         : null,
-      revisions: revisions.map(publicRevision)
+      owned,
+      ownerName: material.owner_name ?? null,
+      revisions: revisions.map((row) => {
+        const mine = row.created_by_sub === req.session.sub
+        const dto = publicRevision(row)
+        if (!owned && !mine) dto.createdBy = null
+        return { ...dto, mine }
+      })
     })
   } catch (err) {
     next(err)
@@ -88,7 +107,8 @@ materialsRouter.post('/:kind/:id/revisions/:rid/activate', requireCatalogInstruc
       materialId: assertUuid(req.params.id, 'Identificador de material'),
       revisionId: assertUuid(req.params.rid, 'Identificador de revisión'),
       platformId: req.session.platformId,
-      ownerSub: req.session.sub
+      ownerSub: req.session.sub,
+      contextId: req.session.contextId
     })
     if (result.status === 'not_found') return res.status(404).json({ error: 'Revisión no encontrada' })
     if (result.status === 'not_ready') {
@@ -112,9 +132,16 @@ materialsRouter.post('/:kind/:id/revisions/:rid/discard', requireCatalogInstruct
       materialId: assertUuid(req.params.id, 'Identificador de material'),
       revisionId: assertUuid(req.params.rid, 'Identificador de revisión'),
       platformId: req.session.platformId,
-      ownerSub: req.session.sub
+      ownerSub: req.session.sub,
+      contextId: req.session.contextId
     })
     if (result.status === 'not_found') return res.status(404).json({ error: 'Revisión no encontrada' })
+    if (result.status === 'not_owned') {
+      return res.status(409).json({
+        error: 'Esta versión la subió otro profesor: sólo puede descartarla quien la subió o el autor del material.',
+        code: 'revision_not_yours'
+      })
+    }
     if (result.status === 'active_revision') {
       return res.status(409).json({
         error: 'No se puede descartar la revisión publicada. Vuelve antes a otra versión.',

--- a/src/routes/uploads.js
+++ b/src/routes/uploads.js
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import logger from '../logger.js'
 import { requireCatalogInstructor } from './auth.js'
 import { assertDocumentId, assertUuid, assertVideoId } from '../media/storage.js'
-import { displayOwnerName } from '../services/sharing.js'
+import { displayOwnerName, getVisibleMaterial } from '../services/sharing.js'
 import {
   assembleChunkedUpload,
   cancelChunkedUpload,
@@ -15,13 +15,11 @@ import {
 } from '../media/chunked-upload.js'
 import {
   createVideoAndJob,
-  createVideoRevisionAndJob,
-  getVideoForOwner
+  createVideoRevisionAndJob
 } from '../services/videos.js'
 import {
   createDocumentAndJob,
-  createDocumentRevisionAndJob,
-  getDocumentForOwner
+  createDocumentRevisionAndJob
 } from '../services/documents.js'
 import { releaseUploadReservation, reserveUpload } from '../services/upload-limits.js'
 
@@ -29,17 +27,23 @@ function ownerFrom (req) {
   return { platformId: req.session.platformId, ownerSub: req.session.sub }
 }
 
-async function assertOwnedMaterial (kind, materialId, req) {
+/**
+ * Material que este profesor puede sustituir: el suyo y el compartido que ve
+ * (ADR-029). El `assert*Id` va delante para que un identificador mal formado no
+ * llegue a la consulta, y `null` acaba en 404: quien no lo ve no sabe si existe.
+ */
+async function assertRevisableMaterial (kind, materialId, req) {
   if (!materialId) return null
-  if (kind === 'video') {
-    const id = assertVideoId(materialId)
-    return (await getVideoForOwner(id, req.session.platformId, req.session.sub)) ? id : null
-  }
-  if (kind === 'pdf') {
-    const id = assertDocumentId(materialId)
-    return (await getDocumentForOwner(id, req.session.platformId, req.session.sub)) ? id : null
-  }
-  return null
+  if (kind !== 'video' && kind !== 'pdf') return null
+  const id = kind === 'video' ? assertVideoId(materialId) : assertDocumentId(materialId)
+  const material = await getVisibleMaterial({
+    kind,
+    id,
+    platformId: req.session.platformId,
+    ownerSub: req.session.sub,
+    contextId: req.session.contextId ?? null
+  })
+  return material ? id : null
 }
 
 /**
@@ -55,7 +59,7 @@ uploadsRouter.post('/', requireUploadAuth, async (req, res, next) => {
     const requestedMaterialId = req.body?.materialId || null
     let materialId = randomUUID()
     if (requestedMaterialId) {
-      materialId = await assertOwnedMaterial(req.body?.kind, requestedMaterialId, req)
+      materialId = await assertRevisableMaterial(req.body?.kind, requestedMaterialId, req)
       if (!materialId) return res.status(404).json({ error: 'Material no encontrado' })
     }
     upload = await createChunkedUpload({
@@ -136,8 +140,9 @@ uploadsRouter.post('/:uploadId/complete', requireUploadAuth, async (req, res, ne
     }
     const replacing = session.manifest.replacing
     if (replacing) {
-      const owned = await assertOwnedMaterial(session.manifest.kind, session.manifest.materialId, req)
-      if (!owned) return res.status(404).json({ error: 'Material no encontrado' })
+      const revisable = await assertRevisableMaterial(
+        session.manifest.kind, session.manifest.materialId, req)
+      if (!revisable) return res.status(404).json({ error: 'Material no encontrado' })
     }
 
     assembled = await assembleChunkedUpload(uploadId, ownerFrom(req))
@@ -148,6 +153,8 @@ uploadsRouter.post('/:uploadId/complete', requireUploadAuth, async (req, res, ne
             videoId: assembled.materialId,
             platformId: req.session.platformId,
             ownerSub: req.session.sub,
+            contextId: req.session.contextId ?? null,
+            createdByName: displayOwnerName(req.session),
             sourcePath: assembled.destination,
             sizeBytes: assembled.size,
             sha256: assembled.sha256,
@@ -172,6 +179,8 @@ uploadsRouter.post('/:uploadId/complete', requireUploadAuth, async (req, res, ne
             documentId: assembled.materialId,
             platformId: req.session.platformId,
             ownerSub: req.session.sub,
+            contextId: req.session.contextId ?? null,
+            createdByName: displayOwnerName(req.session),
             sourcePath: assembled.destination,
             sizeBytes: assembled.size,
             sha256: assembled.sha256,

--- a/src/routes/videos.js
+++ b/src/routes/videos.js
@@ -25,7 +25,7 @@ import {
   revisionDir
 } from '../media/storage.js'
 import { receiveVideoUpload } from '../media/upload.js'
-import { displayOwnerName } from '../services/sharing.js'
+import { displayOwnerName, getVisibleMaterial } from '../services/sharing.js'
 import {
   releaseUploadReservation,
   reserveUpload,
@@ -156,8 +156,16 @@ videosRouter.post('/:id/revisions', requireCatalogInstructor, async (req, res, n
   const reservationId = randomUUID()
   let destination = null
   try {
-    const owned = await getVideoForOwner(videoId, req.session.platformId, req.session.sub)
-    if (!owned) return res.status(404).json({ error: 'Vídeo no encontrado' })
+    // Ver el vídeo basta para sustituirlo (ADR-029): el compartido se corrige
+    // donde está y la corrección llega sola a lo que ya lo enlaza.
+    const visible = await getVisibleMaterial({
+      kind: 'video',
+      id: videoId,
+      platformId: req.session.platformId,
+      ownerSub: req.session.sub,
+      contextId: req.session.contextId
+    })
+    if (!visible) return res.status(404).json({ error: 'Vídeo no encontrado' })
 
     const declaredBytes = declaredUploadBytes(req, config.media.maxUploadBytes)
     await reserveUpload({
@@ -175,6 +183,8 @@ videosRouter.post('/:id/revisions', requireCatalogInstructor, async (req, res, n
       videoId,
       platformId: req.session.platformId,
       ownerSub: req.session.sub,
+      contextId: req.session.contextId,
+      createdByName: displayOwnerName(req.session),
       sourcePath: upload.destination,
       sizeBytes: upload.size,
       sha256: upload.sha256,

--- a/src/services/documents.js
+++ b/src/services/documents.js
@@ -83,6 +83,7 @@ export function createDocumentAndJob ({
     const revision = await insertRevision(client, 'pdf', {
       materialId: id,
       createdBySub: ownerSub ?? 'desconocido',
+      createdByName: ownerName ?? null,
       originalFilename,
       sizeBytes,
       sha256
@@ -98,10 +99,13 @@ export function createDocumentAndJob ({
   })
 }
 
+/** Mismo criterio que en vídeo: quien ve el PDF compartido puede corregirlo. */
 export function createDocumentRevisionAndJob ({
   documentId,
   platformId,
   ownerSub,
+  contextId = null,
+  createdByName = null,
   sourcePath,
   sizeBytes,
   sha256,
@@ -109,14 +113,18 @@ export function createDocumentRevisionAndJob ({
 }) {
   return transaction(async (client) => {
     const { rows } = await client.query(
-      `SELECT id FROM pdf_document WHERE id = $1 AND platform_id = $2 AND owner_sub = $3 FOR UPDATE`,
-      [documentId, platformId, ownerSub]
+      `SELECT m.id FROM pdf_document m
+        WHERE m.id = $1 AND m.platform_id = $2
+          AND ${visibleClause('m', { platform: '$2', owner: '$3', context: '$4', kind: 'pdf' })}
+        FOR UPDATE`,
+      [documentId, platformId, ownerSub, contextId]
     )
     if (rows.length === 0) return { status: 'not_found' }
 
     const revision = await insertRevision(client, 'pdf', {
       materialId: documentId,
       createdBySub: ownerSub,
+      createdByName,
       originalFilename,
       sizeBytes,
       sha256

--- a/src/services/materials.js
+++ b/src/services/materials.js
@@ -222,19 +222,6 @@ export function toMaterialDto (row, { owner = true } = {}) {
 }
 
 /**
- * Un material cualquiera, por tipo e id, dentro del ámbito del profesor.
- * Devuelve `null` (→ 404) para cualquier id que no sea suyo.
- */
-export function getOwnedMaterial ({ kind, id, platformId, ownerSub }) {
-  if (!platformId || !ownerSub || !isUuid(id)) return Promise.resolve(null)
-  const table = kind === 'pdf' ? 'pdf_document' : 'video'
-  return one(
-    `SELECT * FROM ${table} WHERE id = $1 AND platform_id = $2 AND owner_sub = $3`,
-    [id, platformId, ownerSub]
-  )
-}
-
-/**
  * Material PROPIO con ese título dentro de una carpeta concreta.
  *
  * Es lo que convierte una reimportación en versiones nuevas en vez de en

--- a/src/services/revisions.js
+++ b/src/services/revisions.js
@@ -5,6 +5,7 @@ import { many, one, query, transaction } from '../db/index.js'
 import config from '../config.js'
 import logger from '../logger.js'
 import { isUuid, readMediaMeta, removeRevisionFiles, revisionDir, tombstonePath } from '../media/storage.js'
+import { visibleClause } from './sharing.js'
 
 /**
  * Revisiones: el material lógico y el fichero físico dejan de ser lo mismo.
@@ -114,6 +115,7 @@ export function syncMaterialStatus (client, kind, materialId) {
 export async function insertRevision (client, kind, {
   materialId,
   createdBySub,
+  createdByName = null,
   originalFilename,
   sizeBytes,
   sha256
@@ -124,20 +126,20 @@ export async function insertRevision (client, kind, {
   // staging se nombra con él antes de que exista ninguna fila más.
   const id = randomUUID()
   const extraColumns = kind === 'video' ? ', pattern_scope' : ''
-  const extraValues = kind === 'video' ? ', $7' : ''
+  const extraValues = kind === 'video' ? ', $8' : ''
   const params = [materialId, originalFilename ?? null, sizeBytes ?? null,
-    sha256 ?? null, createdBySub, id]
+    sha256 ?? null, createdBySub, id, createdByName ?? null]
   if (kind === 'video') params.push(`${materialId}:${id}`)
 
   try {
     const { rows } = await client.query(
       `INSERT INTO ${revisions}
          (id, ${fk}, revision_number, status, storage_layout, original_filename,
-          size_bytes, sha256, created_by_sub${extraColumns})
+          size_bytes, sha256, created_by_sub, created_by_name${extraColumns})
        VALUES (
          $6, $1,
          COALESCE((SELECT max(revision_number) FROM ${revisions} WHERE ${fk} = $1), 0) + 1,
-         'queued', 'revision', $2, $3, $4, $5${extraValues})
+         'queued', 'revision', $2, $3, $4, $5, $7${extraValues})
        RETURNING *`,
       params
     )
@@ -276,27 +278,52 @@ export async function activateRevisionInTransaction (client, kind, { materialId,
   return { status: 'activated', revision: rows[0] }
 }
 
-/** Activación pedida por el profesor: publicar una candidata o hacer rollback. */
-export function activateRevision ({ kind, materialId, revisionId, platformId, ownerSub }) {
+/**
+ * Activación pedida por el profesor: publicar una candidata o hacer rollback.
+ *
+ * Alcance de trabajo desde ADR-029: quien ve el material compartido también
+ * publica y vuelve atrás. Es la operación inversa de subir una versión y no
+ * puede ser de otro: quien puede sustituir el fichero tiene que poder deshacerlo
+ * sin esperar a que el autor se conecte. Nada se pierde por el camino —la
+ * revisión anterior se queda `retired`, con sus artefactos— y el historial dice
+ * quién subió cada una.
+ */
+export function activateRevision ({
+  kind, materialId, revisionId, platformId, ownerSub, contextId = null
+}) {
   const { table } = kindConfig(kind)
   return transaction(async (client) => {
     const { rows } = await client.query(
-      `SELECT id FROM ${table} WHERE id = $1 AND platform_id = $2 AND owner_sub = $3`,
-      [materialId, platformId, ownerSub]
+      `SELECT m.id FROM ${table} m
+        WHERE m.id = $1 AND m.platform_id = $2
+          AND ${visibleClause('m', { platform: '$2', owner: '$3', context: '$4', kind })}`,
+      [materialId, platformId, ownerSub, contextId]
     )
     if (rows.length === 0) return { status: 'not_found' }
     return activateRevisionInTransaction(client, kind, { materialId, revisionId })
   })
 }
 
-/** Descarta una candidata que aún no se ha publicado; nunca toca la activa. */
-export function discardRevision ({ kind, materialId, revisionId, platformId, ownerSub }) {
+/**
+ * Descarta una candidata que aún no se ha publicado; nunca toca la activa.
+ *
+ * Con material compartido la puerta se abre menos que en publicar: el autor
+ * puede descartar cualquier candidata —si no, una subida ajena a medias le
+ * bloquearía la suya, porque el índice de candidata única sólo admite una viva—
+ * y los demás sólo la que subieron ellos. Cancelar el trabajo de otro no es
+ * corregir un material: es tirarle una subida en curso.
+ */
+export function discardRevision ({
+  kind, materialId, revisionId, platformId, ownerSub, contextId = null
+}) {
   const { table, revisions, fk, jobs } = kindConfig(kind)
   return transaction(async (client) => {
     const { rows: materials } = await client.query(
-      `SELECT id, active_revision_id FROM ${table}
-        WHERE id = $1 AND platform_id = $2 AND owner_sub = $3 FOR UPDATE`,
-      [materialId, platformId, ownerSub]
+      `SELECT m.id, m.active_revision_id, (m.owner_sub = $3) AS mine FROM ${table} m
+        WHERE m.id = $1 AND m.platform_id = $2
+          AND ${visibleClause('m', { platform: '$2', owner: '$3', context: '$4', kind })}
+        FOR UPDATE`,
+      [materialId, platformId, ownerSub, contextId]
     )
     if (materials.length === 0) return { status: 'not_found' }
     if (materials[0].active_revision_id === revisionId) {
@@ -307,6 +334,9 @@ export function discardRevision ({ kind, materialId, revisionId, platformId, own
       [revisionId, materialId]
     )
     if (rows.length === 0) return { status: 'not_found' }
+    if (!materials[0].mine && rows[0].created_by_sub !== ownerSub) {
+      return { status: 'not_owned' }
+    }
 
     // Un trabajo en curso se cancela por el camino del worker (lease +
     // cancel_requested_at); borrar la fila por debajo dejaría un ffmpeg vivo.
@@ -662,6 +692,7 @@ export function publicRevision (row) {
     height: row.height ?? null,
     error: row.error ?? null,
     createdBy: row.created_by_sub,
+    createdByName: row.created_by_name ?? null,
     legalHold: Boolean(row.legal_hold),
     createdAt: row.created_at,
     readyAt: row.ready_at,

--- a/src/services/sharing.js
+++ b/src/services/sharing.js
@@ -15,14 +15,17 @@ import { isUuid } from '../media/storage.js'
  *   · La propiedad. Compartir da acceso de **trabajo**, no de propiedad:
  *
  *        ver · abrir · insertar en un curso · editar metadatos ·
- *        componer y reordenar una colección compartida
+ *        componer y reordenar una colección compartida ·
+ *        subir una versión corregida, publicarla y volver atrás
  *                                                        → cualquier profesor
  *        publicar/despublicar · archivar · borrar · purgar revisiones ·
- *        subir una versión nueva · mover de carpeta
+ *        retener para una investigación · mover de carpeta
  *                                                        → sólo el autor
  *
- * Lo segundo no es cautela decorativa: son las operaciones irreversibles o las
- * que cambian lo que ya están viendo los alumnos de OTRO profesor.
+ * La línea no separa mirar de tocar, sino lo reversible de lo que no tiene
+ * vuelta (ADR-029): una versión nueva deja la anterior `retired` en disco y en
+ * el historial, firmada con quién la subió, y volver a ella es un clic. Ninguna
+ * de las de abajo se deshace, y por eso se quedan con el autor.
  */
 
 /**

--- a/src/services/videos.js
+++ b/src/services/videos.js
@@ -113,6 +113,7 @@ export function createVideoAndJob ({
     const revision = await insertRevision(client, 'video', {
       materialId: id,
       createdBySub: ownerSub ?? 'desconocido',
+      createdByName: ownerName ?? null,
       originalFilename,
       sizeBytes,
       sha256
@@ -131,11 +132,19 @@ export function createVideoAndJob ({
 /**
  * Sustitución: crea la revisión N+1 de un vídeo que ya existe. El UUID lógico no
  * cambia, así que ninguna actividad Moodle hay que tocarla.
+ *
+ * La condición es **ver** el vídeo, no ser su autor (ADR-029): quien usa un
+ * material compartido puede corregirlo, y la corrección llega sola a las
+ * actividades y colecciones que ya lo enlazan, que es justo por lo que no se
+ * duplica el material. La fila sigue siendo de su autor —`owner_sub` no se
+ * toca— y la revisión guarda quién la subió.
  */
 export function createVideoRevisionAndJob ({
   videoId,
   platformId,
   ownerSub,
+  contextId = null,
+  createdByName = null,
   sourcePath,
   sizeBytes,
   sha256,
@@ -143,14 +152,18 @@ export function createVideoRevisionAndJob ({
 }) {
   return transaction(async (client) => {
     const { rows } = await client.query(
-      `SELECT id FROM video WHERE id = $1 AND platform_id = $2 AND owner_sub = $3 FOR UPDATE`,
-      [videoId, platformId, ownerSub]
+      `SELECT m.id FROM video m
+        WHERE m.id = $1 AND m.platform_id = $2
+          AND ${visibleClause('m', { platform: '$2', owner: '$3', context: '$4', kind: 'video' })}
+        FOR UPDATE`,
+      [videoId, platformId, ownerSub, contextId]
     )
     if (rows.length === 0) return { status: 'not_found' }
 
     const revision = await insertRevision(client, 'video', {
       materialId: videoId,
       createdBySub: ownerSub,
+      createdByName,
       originalFilename,
       sizeBytes,
       sha256

--- a/src/ui/assets/catalog.js
+++ b/src/ui/assets/catalog.js
@@ -255,8 +255,8 @@ function childrenOf (parentId) {
 /**
  * `shared` distingue lo que otro profesor de este Moodle ha compartido. No es
  * un adorno: decide qué acciones se ofrecen, porque compartir da acceso de
- * trabajo (ver, editar, insertar) y no de propiedad — archivar, borrar, mover
- * de carpeta, versiones y compartir siguen siendo del autor.
+ * trabajo (ver, editar, insertar y subir una versión corregida) y no de
+ * propiedad — archivar, borrar, mover de carpeta y compartir son del autor.
  */
 function isShared (item) {
   return Boolean(item?.shared)
@@ -921,11 +921,12 @@ function materialCard (item) {
     actions.append(edit)
   }
 
-  // Compartido ≠ propio: se puede usar y corregir el título, pero archivar,
-  // borrar, mover de carpeta o publicar una versión nueva cambiaría lo que ya
-  // están viendo los alumnos de otro profesor. Eso se queda con su autor.
+  // Compartido ≠ propio. Corregir el fichero SÍ (ADR-029): quien usa el material
+  // lo arregla donde está, y la corrección llega sola a las actividades y
+  // colecciones que ya lo enlazan. Archivar, borrar o moverlo de carpeta no:
+  // eso es irreversible o es la biblioteca de su autor.
   const acciones = isShared(item)
-    ? []
+    ? [{ label: 'Versiones…', run: () => { void openRevisions(item) } }]
     : [
         !item.archived && { label: 'Mover a…', run: () => { void openMove({ type: 'material', item }) } },
         { label: 'Versiones…', run: () => { void openRevisions(item) } },
@@ -1197,6 +1198,7 @@ let revisionXhr = null
 async function openRevisions (item) {
   revisioning = item
   el('revisions-heading').textContent = `Versiones de «${item.title}»`
+  el('revision-shared-hint').hidden = true
   el('revision-file').accept = item.kind === 'pdf' ? '.pdf,application/pdf' : VIDEO_EXTENSIONS.join(',')
   el('revision-upload').reset()
   el('revision-submit').disabled = false
@@ -1211,6 +1213,19 @@ async function renderRevisions () {
   list.replaceChildren()
   try {
     const data = await apiJson(`/materials/${item.kind}/${item.id}/revisions`)
+
+    // Sustituir material ajeno cambia lo que ven los alumnos de otro profesor:
+    // se dice antes de subir, no después. `!== false` y no `!`: un servidor
+    // anterior a ADR-029 no manda el campo, y ahí el material sólo puede ser mío.
+    const esMio = data.owned !== false
+    const aviso = el('revision-shared-hint')
+    aviso.hidden = esMio
+    if (!aviso.hidden) {
+      aviso.textContent = `Este material es de ${data.ownerName || 'otro profesor'}. ` +
+        'Al publicar una versión cambia para todos: sus alumnos y los de cualquier ' +
+        'otro curso donde esté insertado. Queda registrado que la subiste tú.'
+    }
+
     list.replaceChildren(...data.revisions.map((revision) => {
       const li = document.createElement('li')
       const text = document.createElement('span')
@@ -1219,7 +1234,8 @@ async function renderRevisions () {
         revision.active ? '· publicada' : '',
         `· ${STATUS_LABEL[revision.status] ?? revision.status}`,
         revision.sizeBytes ? `· ${(revision.sizeBytes / 1048576).toFixed(1)} MB` : '',
-        `· ${new Date(revision.createdAt).toLocaleString('es-ES')}`
+        `· ${new Date(revision.createdAt).toLocaleString('es-ES')}`,
+        revision.createdByName ? `· subida por ${revision.createdByName}` : ''
       ].filter(Boolean).join(' ')
       li.append(text)
 
@@ -1250,7 +1266,11 @@ async function renderRevisions () {
         li.append(activate)
       }
 
-      if (!revision.active && ['uploaded', 'queued', 'processing'].includes(revision.status)) {
+      // Descartar la candidata de otro es tirarle una subida en curso: el autor
+      // del material puede con cualquiera, los demás sólo con la suya.
+      const puedeDescartar = esMio || revision.mine
+      if (puedeDescartar && !revision.active &&
+          ['uploaded', 'queued', 'processing'].includes(revision.status)) {
         const discard = document.createElement('button')
         discard.type = 'button'
         discard.textContent = 'Descartar'

--- a/src/ui/catalog.html
+++ b/src/ui/catalog.html
@@ -370,6 +370,7 @@
         Moodle: las actividades ya creadas siguen funcionando y muestran la
         versión publicada.
       </p>
+      <p class="muted" id="revision-shared-hint" hidden></p>
       <form id="revision-upload">
         <p><input type="file" id="revision-file" required></p>
         <p class="dialog-actions">

--- a/test/integration/catalog.integration.js
+++ b/test/integration/catalog.integration.js
@@ -52,6 +52,7 @@ import { authorizeResource, authorizeCollection } from '../../src/services/autho
 import {
   activateRevision,
   archiveMaterial,
+  discardRevision,
   getActiveRevision,
   listPurgeCandidates,
   listRevisions,
@@ -1390,6 +1391,173 @@ test('compartir da acceso de trabajo, no de propiedad', async () => {
   const renombrada = await renameFolder({ id: carpeta.id, ...scopeLuis, name: 'Renombrada por Luis' })
   assert.ok(renombrada, 'renombrar una carpeta compartida es parte del acceso de trabajo')
   assert.equal(renombrada.name, 'Renombrada por Luis')
+})
+
+test('ADR-029: quien usa un material compartido puede corregirlo, y la corrección llega sola', async () => {
+  // El caso real: Ana sube el temario y lo comparte; Luis encuentra un error en
+  // el segundo vídeo y sube el fichero corregido. Nadie reinserta nada en Moodle.
+  const carpeta = await createFolder({ ...scopeA, ownerName: 'Ana', name: `Temario ${randomUUID()}` })
+  const videos = []
+  for (const n of [1, 2, 3]) {
+    videos.push(await readyVideo({ title: `Tema ${n}`, folderId: carpeta.id }))
+  }
+  const coleccion = await createCollection({
+    ...scopeA,
+    ownerName: 'Ana',
+    title: `Curso ${randomUUID()}`,
+    folderId: carpeta.id,
+    items: videos.map((id) => ({ kind: 'video', id }))
+  })
+  await setFolderVisibility({ id: carpeta.id, ...scopeA, isPublic: true })
+
+  const anterior = await getActiveRevision({ kind: 'video', materialId: videos[1] })
+  const subida = await createVideoRevisionAndJob({
+    videoId: videos[1],
+    ...scopeLuis,
+    createdByName: 'Luis',
+    sourcePath: `/tmp/${randomUUID()}.mp4`,
+    sizeBytes: 4096,
+    originalFilename: 'tema-2-corregido.mp4'
+  })
+  assert.equal(subida.status, 'queued')
+  await finishJob(videoQueue, videos[1])
+
+  // 1 · El material de Ana: mismo UUID, mismo dueño, fichero nuevo publicado.
+  const material = await one(
+    'SELECT owner_sub, active_revision_id, original_filename FROM video WHERE id = $1',
+    [videos[1]]
+  )
+  assert.equal(material.owner_sub, ANA,
+    'corregir no cambia de dueño: la firma T24 de lo ya insertado sigue valiendo')
+  assert.notEqual(material.active_revision_id, anterior.id)
+  assert.equal(material.original_filename, 'tema-2-corregido.mp4')
+
+  // 2 · La colección de Ana: los mismos elementos, sirviendo la revisión nueva.
+  const items = await loadItems(coleccion.id)
+  assert.deepEqual(items.map((i) => i.id), videos, 'la colección no se recompone')
+  assert.equal(items[1].active_revision_id, material.active_revision_id)
+
+  // 3 · Y en la biblioteca de Luis sigue siendo de Ana, ya corregido.
+  const visto = (await listMaterials(scopeLuis)).materials.find((m) => m.id === videos[1])
+  assert.equal(visto.shared, true)
+  assert.equal(visto.status, 'ready')
+
+  // El historial dice quién subió cada versión, que es lo que hace esto revisable.
+  const historial = await listRevisions({ kind: 'video', materialId: videos[1] })
+  const nueva = historial.find((r) => r.id === material.active_revision_id)
+  assert.equal(nueva.created_by_sub, LUIS)
+  assert.equal(nueva.created_by_name, 'Luis')
+  assert.equal(historial.find((r) => r.id === anterior.id).status, 'retired',
+    'la versión de Ana se retira, no se borra: se puede volver a ella')
+
+  // Los apuntes en PDF del mismo tema, por el mismo camino.
+  const documentId = await readyDocument({ title: 'Apuntes del tema 2', folderId: carpeta.id })
+  const pdf = await createDocumentRevisionAndJob({
+    documentId,
+    ...scopeLuis,
+    createdByName: 'Luis',
+    sourcePath: `/tmp/${randomUUID()}.pdf`,
+    sizeBytes: 1024,
+    originalFilename: 'apuntes-corregidos.pdf'
+  })
+  assert.equal(pdf.status, 'queued')
+  assert.equal(pdf.revision.created_by_sub, LUIS)
+})
+
+test('ADR-029: publicar y volver atrás son de los dos, cada uno por su lado', async () => {
+  const carpeta = await createFolder({ ...scopeA, name: `Rollback ${randomUUID()}` })
+  const videoId = await readyVideo({ title: 'Con dos versiones', folderId: carpeta.id })
+  await setFolderVisibility({ id: carpeta.id, ...scopeA, isPublic: true })
+
+  const primera = await getActiveRevision({ kind: 'video', materialId: videoId })
+  await createVideoRevisionAndJob({
+    videoId,
+    ...scopeLuis,
+    createdByName: 'Luis',
+    sourcePath: `/tmp/${randomUUID()}.mp4`,
+    sizeBytes: 2048,
+    originalFilename: 'corregido.mp4'
+  })
+  await finishJob(videoQueue, videoId)
+  const segunda = await getActiveRevision({ kind: 'video', materialId: videoId })
+  assert.notEqual(segunda.id, primera.id)
+
+  // Ana no se queda mirando: vuelve a la suya sin esperar a nadie.
+  const vuelta = await activateRevision({
+    kind: 'video', materialId: videoId, revisionId: primera.id, ...scopeA
+  })
+  assert.equal(vuelta.status, 'activated')
+
+  // Y Luis puede volver a publicar la corregida: es la misma operación.
+  const republicada = await activateRevision({
+    kind: 'video', materialId: videoId, revisionId: segunda.id, ...scopeLuis
+  })
+  assert.equal(republicada.status, 'activated')
+  assert.equal(
+    (await one('SELECT active_revision_id FROM video WHERE id = $1', [videoId])).active_revision_id,
+    segunda.id
+  )
+})
+
+test('ADR-029: descartar la candidata de otro no; la propia sí', async () => {
+  const carpeta = await createFolder({ ...scopeA, name: `Candidatas ${randomUUID()}` })
+  const videoId = await readyVideo({ title: 'Con candidata', folderId: carpeta.id })
+  await setFolderVisibility({ id: carpeta.id, ...scopeA, isPublic: true })
+
+  const deAna = await createVideoRevisionAndJob({
+    videoId, ...scopeA, createdByName: 'Ana', sourcePath: `/tmp/${randomUUID()}.mp4`, sizeBytes: 512
+  })
+  assert.equal(
+    (await discardRevision({
+      kind: 'video', materialId: videoId, revisionId: deAna.revision.id, ...scopeLuis
+    })).status,
+    'not_owned',
+    'tirarle a otro una subida en curso no es corregir un material'
+  )
+
+  // La autora sí puede con cualquiera: sólo cabe una candidata viva, así que si
+  // no pudiera, una subida ajena a medias le bloquearía la suya.
+  assert.equal(
+    (await discardRevision({
+      kind: 'video', materialId: videoId, revisionId: deAna.revision.id, ...scopeA
+    })).status,
+    'discarded'
+  )
+
+  const deLuis = await createVideoRevisionAndJob({
+    videoId, ...scopeLuis, createdByName: 'Luis', sourcePath: `/tmp/${randomUUID()}.mp4`, sizeBytes: 512
+  })
+  assert.equal(
+    (await discardRevision({
+      kind: 'video', materialId: videoId, revisionId: deLuis.revision.id, ...scopeLuis
+    })).status,
+    'discarded',
+    'la suya la descarta quien la subió, sin molestar al autor del material'
+  )
+})
+
+test('ADR-029: sin compartir no hay corrección que valga, ni desde otra instancia', async () => {
+  const videoId = await readyVideo({ title: 'Privado de Ana' })
+  const activa = await getActiveRevision({ kind: 'video', materialId: videoId })
+
+  for (const scope of [scopeLuis, scopeB]) {
+    assert.equal(
+      (await createVideoRevisionAndJob({
+        videoId, ...scope, sourcePath: `/tmp/${randomUUID()}.mp4`, sizeBytes: 128
+      })).status,
+      'not_found'
+    )
+    assert.equal(
+      (await activateRevision({
+        kind: 'video', materialId: videoId, revisionId: activa.id, ...scope
+      })).status,
+      'not_found'
+    )
+  }
+  assert.equal(
+    (await one('SELECT active_revision_id FROM video WHERE id = $1', [videoId])).active_revision_id,
+    activa.id
+  )
 })
 
 test('una colección compartida la ve, la edita y la duplica el otro profesor', async () => {

--- a/test/integration/chunked-upload.integration.js
+++ b/test/integration/chunked-upload.integration.js
@@ -8,27 +8,41 @@ import { closeDatabase, many, one, query } from '../../src/db/index.js'
 import { runMigrations } from '../../src/db/migrate.js'
 import { issueSession, verifySession } from '../../src/session.js'
 import { registerPlaybackGrant } from '../../src/services/playback-grants.js'
+import { createFolder, setFolderVisibility } from '../../src/services/folders.js'
 
 const PLATFORM_ID = randomUUID()
 const OWNER_SUB = 'teacher-chunked-upload'
+const LUIS_SUB = 'teacher-chunked-luis'
 let server
 let baseUrl
 let token
+let luisToken
 
-function headers (extra = {}) {
-  return { Authorization: `Bearer ${token}`, ...extra }
+function headers (extra = {}, auth) {
+  return { Authorization: `Bearer ${auth ?? token}`, ...extra }
 }
 
-async function json (url, options = {}) {
+async function json (url, options = {}, auth) {
   const response = await fetch(`${baseUrl}${url}`, {
     ...options,
-    headers: headers(options.headers)
+    headers: headers(options.headers, auth)
   })
   const payload = response.status === 204 ? null : await response.json()
   return { response, payload }
 }
 
-async function upload (content, { materialId = null, filename = 'clase.mp4' } = {}) {
+/** Sesión de catálogo lista para usar: emitida y registrada como grant. */
+async function sesionDe (sub, name) {
+  const emitida = issueSession({
+    sub, platformId: PLATFORM_ID, name, isInstructor: true, mode: 'catalog'
+  })
+  await registerPlaybackGrant(verifySession(emitida))
+  return emitida
+}
+
+async function upload (
+  content, { materialId = null, filename = 'clase.mp4', folderId = null, as } = {}
+) {
   const started = await json('/uploads', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -37,9 +51,10 @@ async function upload (content, { materialId = null, filename = 'clase.mp4' } = 
       filename,
       size: content.length,
       title: 'Cálculo por fragmentos',
+      folderId,
       materialId
     })
-  })
+  }, as)
   assert.equal(started.response.status, 201)
   const session = started.payload
 
@@ -48,12 +63,12 @@ async function upload (content, { materialId = null, filename = 'clase.mp4' } = 
     const chunk = content.subarray(start, start + session.chunkBytes)
     const response = await fetch(`${baseUrl}/uploads/${session.uploadId}/chunks/${index}`, {
       method: 'PUT',
-      headers: headers({ 'Content-Type': 'application/octet-stream' }),
+      headers: headers({ 'Content-Type': 'application/octet-stream' }, as),
       body: chunk
     })
     assert.equal(response.status, 204)
     if (index === 0) {
-      const progress = await json(`/uploads/${session.uploadId}`)
+      const progress = await json(`/uploads/${session.uploadId}`, {}, as)
       assert.deepEqual(progress.payload.received, [0])
     }
   }
@@ -62,7 +77,7 @@ async function upload (content, { materialId = null, filename = 'clase.mp4' } = 
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: '{}'
-  })
+  }, as)
   assert.equal(completed.response.status, 202)
   return { ...completed.payload, uploadId: session.uploadId }
 }
@@ -79,14 +94,8 @@ test.before(async () => {
              'https://chunks.example.test/keys')`,
     [PLATFORM_ID]
   )
-  token = issueSession({
-    sub: OWNER_SUB,
-    platformId: PLATFORM_ID,
-    name: 'Profesora Chunks',
-    isInstructor: true,
-    mode: 'catalog'
-  })
-  await registerPlaybackGrant(verifySession(token))
+  token = await sesionDe(OWNER_SUB, 'Profesora Chunks')
+  luisToken = await sesionDe(LUIS_SUB, 'Luis Compartido')
   const app = await createApp()
   server = app.listen(0, '127.0.0.1')
   await new Promise((resolve, reject) => {
@@ -149,4 +158,83 @@ test('HTTP: alta y sustitución se reintegran sin cambiar el UUID lógico', asyn
   const gone = await json(`/uploads/${second.uploadId}`)
   assert.equal(gone.response.status, 404)
   assert.equal(gone.payload.code, 'upload_not_found')
+})
+
+/**
+ * ADR-029 sobre el protocolo real, que es donde vive la comprobación: Ana sube
+ * el vídeo en una carpeta compartida y Luis, que lo usa, sube la corrección.
+ * Mismo UUID, misma dueña, y la versión queda a nombre de quien la subió.
+ */
+test('HTTP: otro profesor sustituye el material compartido y la versión queda a su nombre', async () => {
+  const carpeta = await createFolder({
+    platformId: PLATFORM_ID, ownerSub: OWNER_SUB, name: `Compartida ${randomUUID()}`
+  })
+  await setFolderVisibility({
+    id: carpeta.id, platformId: PLATFORM_ID, ownerSub: OWNER_SUB, isPublic: true
+  })
+
+  const original = await upload(
+    Buffer.from('\x00\x00\x00\x18ftypisomvideo-de-ana'), { folderId: carpeta.id }
+  )
+  const primera = await one(
+    'SELECT revision_id FROM transcode_job WHERE video_id = $1', [original.id]
+  )
+  // Aquí no corre ffmpeg: se publica la primera a mano para llegar al estado
+  // desde el que se sustituye, igual que en la prueba de arriba.
+  await query("UPDATE video_revision SET status = 'ready', ready_at = now() WHERE id = $1",
+    [primera.revision_id])
+  await query("UPDATE transcode_job SET status = 'done', finished_at = now() WHERE revision_id = $1",
+    [primera.revision_id])
+  await query("UPDATE video SET status = 'ready', active_revision_id = $1 WHERE id = $2",
+    [primera.revision_id, original.id])
+
+  const corregido = await upload(
+    Buffer.from('\x00\x00\x00\x18ftypisomcorregido-por-luis'),
+    { materialId: original.id, as: luisToken }
+  )
+  assert.equal(corregido.id, original.id, 'corregir no crea un UUID nuevo')
+  assert.notEqual(corregido.revisionId, primera.revision_id)
+  assert.equal(
+    (await one('SELECT owner_sub FROM video WHERE id = $1', [original.id])).owner_sub,
+    OWNER_SUB,
+    'el material sigue siendo de quien lo subió'
+  )
+
+  const comoLuis = await json(`/materials/video/${original.id}/revisions`, {}, luisToken)
+  assert.equal(comoLuis.response.status, 200)
+  assert.equal(comoLuis.payload.owned, false)
+  assert.equal(comoLuis.payload.ownerName, 'Profesora Chunks')
+  const suya = comoLuis.payload.revisions.find((r) => r.id === corregido.revisionId)
+  assert.equal(suya.mine, true)
+  assert.equal(suya.createdByName, 'Luis Compartido')
+  const deAna = comoLuis.payload.revisions.find((r) => r.id === primera.revision_id)
+  assert.equal(deAna.mine, false)
+  assert.equal(deAna.createdBy, null, 'el sub de otro profesor no tiene por qué viajar')
+
+  // Y para la autora, su historial de siempre, diciendo quién subió cada una.
+  const comoAna = await json(`/materials/video/${original.id}/revisions`)
+  assert.equal(comoAna.payload.owned, true)
+  assert.equal(
+    comoAna.payload.revisions.find((r) => r.id === corregido.revisionId).createdBy, LUIS_SUB
+  )
+
+  // Y lo que NO está compartido sigue cerrado para el mismo Luis: la puerta la
+  // abre la carpeta pública, no el hecho de ser profesor de la instancia.
+  const privado = await upload(Buffer.from('\x00\x00\x00\x18ftypisomsolo-de-ana'))
+  const reservar = await json('/uploads', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'video', filename: 'x.mp4', size: 16, materialId: privado.id })
+  }, luisToken)
+  assert.equal(reservar.response.status, 404, 'sin compartir no se puede ni reservar la subida')
+
+  const publicar = await json(
+    `/materials/video/${privado.id}/revisions/${privado.revisionId}/activate`,
+    { method: 'POST' }, luisToken
+  )
+  assert.equal(publicar.response.status, 404)
+  assert.equal(
+    (await json(`/materials/video/${privado.id}/revisions`, {}, luisToken)).response.status, 404,
+    'ni el historial: un material que no se ve no existe'
+  )
 })

--- a/test/sharing.test.js
+++ b/test/sharing.test.js
@@ -56,6 +56,53 @@ test('la migración de compartición es aditiva y no destruye nada', async () =>
   assert.match(sql, /CREATE OR REPLACE VIEW catalog_folder_shared/)
 })
 
+/** Cuerpo de una función exportada, hasta la siguiente. */
+function cuerpoDe (fuente, nombre) {
+  const inicio = fuente.indexOf(`function ${nombre} (`)
+  assert.notEqual(inicio, -1, `falta ${nombre}`)
+  const siguiente = fuente.indexOf('\nexport ', inicio + 1)
+  return fuente.slice(inicio, siguiente === -1 ? undefined : siguiente)
+}
+
+test('corregir el fichero es trabajo; lo irreversible sigue siendo del autor', async () => {
+  // ADR-029. La línea no está donde parece: no separa «tocar» de «mirar», sino
+  // lo que se puede deshacer de lo que no. Sustituir el fichero deja las dos
+  // versiones en el historial y firmadas con quién las subió; archivar, purgar o
+  // retener para una investigación no tienen vuelta.
+  const revisions = await readFile(path.join(projectRoot, 'src/services/revisions.js'), 'utf8')
+  const videos = await readFile(path.join(projectRoot, 'src/services/videos.js'), 'utf8')
+  const documents = await readFile(path.join(projectRoot, 'src/services/documents.js'), 'utf8')
+
+  for (const [nombre, fuente] of [
+    ['createVideoRevisionAndJob', videos],
+    ['createDocumentRevisionAndJob', documents],
+    ['activateRevision', revisions],
+    ['discardRevision', revisions]
+  ]) {
+    assert.match(cuerpoDe(fuente, nombre), /visibleClause\(/,
+      `${nombre} debe filtrar por visibilidad, no sólo por propiedad`)
+  }
+
+  for (const nombre of [
+    'archiveMaterial', 'restoreMaterial', 'purgeRevisionManually', 'setRevisionLegalHold'
+  ]) {
+    const cuerpo = cuerpoDe(revisions, nombre)
+    assert.match(cuerpo, /owner_sub = \$3/, `${nombre} debe seguir exigiendo propiedad`)
+    assert.doesNotMatch(cuerpo, /visibleClause/,
+      `${nombre} no puede abrirse a material compartido: no tiene vuelta atrás`)
+  }
+})
+
+test('la migración que registra al autor de cada versión no destruye nada', async () => {
+  const sql = await readFile(path.join(projectRoot, 'migrations/017_revision_autor.sql'), 'utf8')
+  for (const prohibido of [/DROP\s+TABLE/i, /DROP\s+COLUMN/i, /TRUNCATE/i, /DELETE\s+FROM/i, /UPDATE\s+/i]) {
+    assert.doesNotMatch(sql, prohibido, `la migración 017 no puede contener ${prohibido}`)
+  }
+  for (const tabla of ['video_revision', 'pdf_revision']) {
+    assert.match(sql, new RegExp(`ALTER TABLE ${tabla}\\s+ADD COLUMN IF NOT EXISTS created_by_name text`))
+  }
+})
+
 test('las acciones que cambian lo que ven los alumnos siguen siendo del autor', async () => {
   const folders = await readFile(path.join(projectRoot, 'src/services/folders.js'), 'utf8')
   const collections = await readFile(path.join(projectRoot, 'src/services/collections.js'), 'utf8')

--- a/test/ui-catalogo.test.js
+++ b/test/ui-catalogo.test.js
@@ -124,3 +124,32 @@ test('el material se ordena como se lee, con los números en su sitio', async ()
     ['2 · Límites', '9 · Derivadas', '10 · Repaso']
   )
 })
+
+/**
+ * ADR-029: el material compartido se corrige donde está. La tarjeta de otro
+ * profesor ofrece «Versiones…» y sólo eso, y el diálogo dice de quién es antes
+ * de que nadie suba nada, porque publicar cambia lo que ven sus alumnos.
+ */
+test('la tarjeta compartida ofrece versiones, y avisa de quién es el material', async () => {
+  const html = await readFile(path.join(uiDir, 'catalog.html'), 'utf8')
+  const code = await readFile(path.join(uiDir, 'assets/catalog.js'), 'utf8')
+
+  // Rama compartida del ternario: desde `isShared(item)` hasta el `: [` de la otra.
+  const inicio = code.indexOf('const acciones = isShared(item)')
+  assert.notEqual(inicio, -1, 'falta el menú de acciones de la tarjeta')
+  const compartida = code.slice(inicio, code.indexOf('    : [', inicio))
+  assert.match(compartida, /\{ label: 'Versiones…', run: \(\) => \{ void openRevisions\(item\) \} \}/,
+    'el menú de lo compartido tiene que ofrecer las versiones')
+  for (const prohibida of ['Archivar', 'Borrar definitivamente', 'Mover a…']) {
+    assert.doesNotMatch(compartida, new RegExp(prohibida),
+      `${prohibida} no puede ofrecerse sobre material de otro profesor`)
+  }
+
+  assert.match(html, /id="revision-shared-hint"/, 'falta el aviso en el diálogo')
+  assert.match(code, /const esMio = data\.owned !== false\n\s*const aviso = el\('revision-shared-hint'\)\n\s*aviso\.hidden = esMio/,
+    'el aviso sale exactamente cuando el material es de otro')
+  assert.match(code, /revision\.createdByName \? `· subida por \$\{revision\.createdByName\}` : ''/,
+    'cada versión tiene que decir quién la subió')
+  assert.match(code, /const puedeDescartar = esMio \|\| revision\.mine/,
+    'descartar la candidata de otro no se ofrece: el servidor la rechaza')
+})


### PR DESCRIPTION
## El caso

**Profesor A** sube tres vídeos y arma la colección. **Profesor B** encuentra un
error en uno y sube la versión corregida. Al publicarse:

1. **El material de A** queda corregido — mismo UUID, misma dueña.
2. **Las colecciones donde está insertado** sirven ya la versión nueva, sin
   recomponerlas.
3. **La biblioteca compartida de B** lo enseña corregido.

Y las **actividades de Moodle ya creadas** siguen funcionando sin tocarlas: el
UUID no se mueve, que es justo para lo que existen las revisiones.

## Qué cambia y qué no

La frontera de lo compartido deja de separar «mirar» de «tocar» y pasa a separar
**lo reversible de lo que no tiene vuelta**:

| Cualquier profesor que lo vea | Sólo el autor |
|---|---|
| Ver, abrir e insertar en su curso | Publicar y despublicar |
| Editar título y descripción | Archivar, restaurar y borrar |
| **Subir una versión corregida** | Purgar revisiones y retenerlas para una investigación |
| **Publicar una versión y volver a una anterior** | Mover de carpeta y borrar la carpeta |
| Descartar la candidata **que subió él** | Descartar cualquier candidata |

La puerta es exactamente la que ya abría editar el título: `visibleClause` de
`sharing.js` —carpeta o colección compartida, o material desplegado en tu curso—.
**No hay camino nuevo**: un UUID que no se ve sigue respondiendo 404, y
`platform_id` sigue sin tener puertas.

## Los tres cierres que van con ello

Sin esto sería sólo aflojar una regla:

1. **Cada versión dice quién la subió.** `created_by_sub` ya se guardaba; la
   migración `017` añade `created_by_name` para que el historial lo lea una
   persona. El diálogo muestra «· subida por Fulano» en cada línea.
2. **Se avisa antes de subir**, no después: de quién es el material y que
   publicar cambia lo que ven sus alumnos y los de cualquier otro curso donde
   esté insertado.
3. **La candidata de otro no se descarta.** El autor puede con cualquiera —sólo
   cabe una candidata viva, y si no, una subida ajena a medias le bloquearía la
   suya—; los demás, sólo con la que subieron.

## Lo que hay que asumir

- Un profesor con acceso **puede cambiar lo que ven los alumnos de otro**. Es la
  contrapartida deliberada: por eso el historial firma quién y volver atrás es un
  clic. Quien no lo quiera, deja de compartir la carpeta.
- **No hay aviso al autor**: la herramienta no tiene canal de notificación. El
  cambio se ve al abrir «Versiones…». Limitación conocida.
- El alumno con el vídeo **abierto** sigue viendo la versión anterior hasta que
  recargue: la revisión se fija en el launch, y cambiarla a mitad mezclaría dos
  versiones.
- El almacenamiento de la versión nueva cuenta en la cuota del **autor** (la
  revisión cuelga de su material); la reserva de la subida, en la de quien sube.
- **Importar una carpeta sigue sin tocar material ajeno**: coincidir el título no
  puede reescribir lo de otro. Corregir es un acto explícito.

## Compatibilidad con lo desplegado

- Migración `017` **aditiva y reejecutable** (`ADD COLUMN IF NOT EXISTS`), nula en
  todo lo anterior. No toca ni una fila.
- `owner_sub` no se mueve en ningún camino → la firma **T24**
  (`custom.resourcesig`) de lo ya insertado sigue valiendo. **Cero actividades
  que reinsertar.**
- Cliente viejo contra servidor nuevo: el diálogo degrada a lo de antes.

## Comprobado

`npm run lint` limpio · `npm test` **370** · `npm run test:integration` **154**,
con seis pruebas nuevas: el recorrido A→B completo con la colección, publicar y
volver atrás por los dos lados, el descarte acotado, lo no compartido cerrado
(también desde otra instancia), el PDF por el mismo camino y una prueba **sobre
las rutas HTTP reales** con dos sesiones LTI distintas, que comprueba el 404 y
que el `sub` del otro profesor no viaja en la respuesta.

Motivo, alternativas descartadas y cómo revertirlo: **ADR-029** en
`docs/decisiones.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt
