### PR TITLE
fix(visor): la marca del PDF se reparte por la hoja en vez de repetirse

### DIFF
--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -515,10 +515,15 @@ Conviene tener claro contra qué sirve cada cosa, porque es fácil confundirlas:
 | Sello de la descarga (ADR-017) | Dentro del PDF generado al vuelo | Una copia descargada, hasta que alguien la reprocese |
 | Nada | — | Una filtración de los bytes originales |
 
-La marca de fondo se calibra con `--pdf-mark-alpha` en `app.css`. El criterio es
-el más bajo que todavía se lea al fotografiar la pantalla: por debajo de `.10` la
-compresión de una cámara de móvil se la come, y por encima de `.18` empieza a
-molestar sobre texto pequeño.
+La marca de fondo tiene **dos** mandos, y conviene no confundirlos:
+
+| Mando | Dónde | Criterio |
+|---|---|---|
+| Cuánto se ve | `--pdf-mark-alpha` en `app.css` | el más bajo que todavía se lea al fotografiar la pantalla: por debajo de `.10` la compresión de una cámara de móvil se la come, y por encima de `.18` molesta sobre texto pequeño |
+| Cada cuánto se repite | `pdfMarkTile` en `pdf-mark.js` | una marca por cada cuadro de 480 px, unas cinco o seis por hoja; la densidad **no** la fija el largo de la etiqueta |
+
+El segundo importa tanto como el primero: un PDF de apuntes se estudia, y una
+marca cada dos renglones no deja leer por tenue que sea.
 
 | | Vídeo | PDF |
 |---|---|---|

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -1150,9 +1150,10 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
  * Marca de fondo con la identidad, repetida sobre toda la hoja.
  *
  * El equilibrio que se busca: invisible de facto al leer, presente en una foto
- * del monitor. Se calibra con --pdf-mark-alpha y nada más; por debajo de .10 la
- * compresión de una cámara de móvil se la puede comer, y por encima de .18
- * empieza a estorbar sobre texto pequeño.
+ * del monitor. Dos mandos, y este es sólo uno: cuánto se ve —--pdf-mark-alpha,
+ * aquí— y cada cuántos píxeles se repite, que vive en `pdfMarkTile` de
+ * `pdf-mark.js`. Por debajo de .10 la compresión de una cámara de móvil se la
+ * puede comer, y por encima de .18 empieza a estorbar sobre texto pequeño.
  *
  * Se sirve en el suelo de esa banda: con .13 los apuntes de texto denso se leían
  * peor de lo aceptable en pantalla. Bajar más exige salir de la banda, y eso ya

--- a/src/ui/assets/pdf-component.js
+++ b/src/ui/assets/pdf-component.js
@@ -1,5 +1,5 @@
 import * as pdfjs from '/vendor/pdfjs/pdf.min.mjs'
-import { pdfMarkLabel } from './pdf-mark.js'
+import { pdfMarkLabel, pdfMarkTile } from './pdf-mark.js'
 
 /**
  * Visor de PDF con PDF.js.
@@ -64,30 +64,20 @@ function pageIdentityMark (user) {
   svg.setAttribute('aria-hidden', 'true')
   svg.setAttribute('focusable', 'false')
 
-  // Un patrón SVG RECORTA lo que se sale de la baldosa, no lo continúa en la
-  // siguiente. Con un DNI da igual, pero el sustituto es el nombre y
-  // «María del Carmen Fernández» se quedaría a medias, que es peor que no
-  // marcar: la baldosa se ensancha con la etiqueta.
-  // ~12 px por carácter con la fuente monoespaciada de `.pdf-page-mark`.
-  const textWidth = label.length * 12
-  const gap = 70
-  // Dos etiquetas por baldosa, cada una con su hueco: la segunda empieza donde
-  // acaba la primera más el hueco, así que la baldosa mide justo el doble y
-  // ninguna llega al borde.
-  const tileWidth = 2 * (textWidth + gap)
-  const tileHeight = 165
+  // Cada cuánto se repite: `pdfMarkTile`, que es donde se razona la densidad.
+  const tile = pdfMarkTile(label)
 
   const pattern = window.document.createElementNS(SVG_NS, 'pattern')
   pattern.setAttribute('id', id)
   pattern.setAttribute('patternUnits', 'userSpaceOnUse')
-  pattern.setAttribute('width', String(tileWidth))
-  pattern.setAttribute('height', String(tileHeight))
+  pattern.setAttribute('width', String(tile.width))
+  pattern.setAttribute('height', String(tile.height))
   // La diagonal evita que la marca se alinee con los renglones y se lea como
   // parte del texto; también sobrevive mejor a un recorte de la foto.
   pattern.setAttribute('patternTransform', 'rotate(-30)')
 
-  // Dos pasadas desplazadas por baldosa: cubren el hueco que deja la diagonal.
-  for (const [x, y] of [[0, 55], [textWidth + gap, 135]]) {
+  // Dos pasadas desplazadas por baldosa: así no quedan alineadas en columnas.
+  for (const [x, y] of tile.labels) {
     const text = window.document.createElementNS(SVG_NS, 'text')
     text.setAttribute('x', String(x))
     text.setAttribute('y', String(y))

--- a/src/ui/assets/pdf-mark.js
+++ b/src/ui/assets/pdf-mark.js
@@ -25,3 +25,38 @@ export function pdfMarkLabel (user) {
   }
   return null
 }
+
+/**
+ * Cada cuánto se repite la marca sobre la hoja.
+ *
+ * Es la decisión que separa «marca de fondo» de «ruido encima del texto», y por
+ * eso vive aquí y no dentro del dibujo: un PDF de apuntes se estudia, y una
+ * marca cada dos renglones no deja leer aunque sea tenue.
+ *
+ * La densidad **no la fija el largo de la etiqueta**. Antes la baldosa medía lo
+ * que midiera el texto más un hueco fijo, así que un DNI —nueve caracteres—
+ * salía unas cincuenta veces por hoja. Ahora la manda `CELDA`: una marca por
+ * cada cuadro de ese lado, salgan cinco o seis por página, y el largo de la
+ * etiqueta sólo interviene si no cabe.
+ *
+ * Dos filas por baldosa, la segunda desplazada media baldosa, para que no
+ * queden alineadas en columnas. Un patrón SVG **recorta** lo que se sale de su
+ * baldosa en vez de continuarlo en la siguiente, y de ahí el margen: el nombre
+ * completo —el sustituto cuando Moodle no manda identidad— tiene que caber
+ * entero o se leería a medias, que es peor que no marcar.
+ *
+ * ~12 px por carácter con la fuente monoespaciada de `.pdf-page-mark`.
+ */
+const CELDA = 480
+
+export function pdfMarkTile (label) {
+  const textWidth = String(label ?? '').length * 12
+  const cell = Math.max(textWidth + 120, CELDA)
+  return {
+    textWidth,
+    width: 2 * cell,
+    height: CELDA,
+    // [x, y] de cada etiqueta dentro de la baldosa.
+    labels: [[0, 165], [cell, 405]]
+  }
+}

--- a/test/pdf-mark.test.js
+++ b/test/pdf-mark.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { pdfMarkLabel } from '../src/ui/assets/pdf-mark.js'
+import { pdfMarkLabel, pdfMarkTile } from '../src/ui/assets/pdf-mark.js'
 
 /**
  * Marca de fondo del visor de PDF: la identidad del lector repetida sobre la
@@ -29,6 +29,46 @@ test('sin identidad no se estampa una marca vacía', () => {
   assert.equal(pdfMarkLabel({}), null)
   assert.equal(pdfMarkLabel(), null)
   assert.equal(pdfMarkLabel({ identity: '   ', name: '' }), null)
+})
+
+/** Marcas que caen en una hoja del visor: 1080 px de ancho, A4 a esa escala. */
+function marcasPorHoja (label, ancho = 1080, alto = 1400) {
+  const tile = pdfMarkTile(label)
+  return (ancho / tile.width) * (alto / tile.height) * tile.labels.length
+}
+
+test('la marca se reparte por la hoja, no se repite sobre cada renglón', () => {
+  // El PDF se estudia. Con la baldosa atada al ancho del texto, un DNI salía
+  // unas cincuenta veces por página y la marca dejaba de ser fondo para ser
+  // ruido. Media docena cubre la hoja sin competir con lo que hay que leer.
+  const salen = marcasPorHoja('12345678Z')
+  assert.ok(salen >= 4 && salen <= 9,
+    `salen ${salen.toFixed(1)} marcas por hoja; la banda calibrada es 4–9`)
+})
+
+test('la densidad no la decide el largo de la etiqueta', () => {
+  // Un DNI y un nombre corto tienen que marcar igual de poco: si la baldosa la
+  // fija el texto, la etiqueta corta se repite el triple.
+  const dni = pdfMarkTile('12345678Z')
+  const corto = pdfMarkTile('Ana Ruiz')
+  assert.deepEqual([dni.width, dni.height], [corto.width, corto.height])
+
+  // Un nombre muy largo sí ensancha la baldosa, y con ella el hueco: el patrón
+  // RECORTA lo que se sale, y media marca es peor que ninguna.
+  const largo = pdfMarkTile('María del Carmen Fernández Ballesteros')
+  const [, [x2]] = largo.labels
+  assert.ok(x2 + largo.textWidth <= largo.width,
+    'la segunda etiqueta de la baldosa tiene que caber entera')
+  assert.ok(marcasPorHoja('María del Carmen Fernández Ballesteros') <= marcasPorHoja('12345678Z'))
+})
+
+test('las dos etiquetas de la baldosa van desplazadas entre sí', () => {
+  // Alineadas quedarían en columnas y se leerían como una tabla de fondo.
+  const tile = pdfMarkTile('12345678Z')
+  const [[x1, y1], [x2, y2]] = tile.labels
+  assert.notEqual(x1, x2)
+  assert.notEqual(y1, y2)
+  assert.ok(y1 > 0 && y2 < tile.height, 'las dos filas tienen que caber en la baldosa')
 })
 
 test('la marca se construye sin innerHTML: la identidad nunca se interpola en marcado', async () => {


### PR DESCRIPTION
Bajar la opacidad no era suficiente, y el motivo no era el tono: era **cuántas
veces sale**. La baldosa del patrón la fijaba el ancho de la etiqueta —el texto
más un hueco de 70 px—, así que un DNI de nueve caracteres se estampaba **unas
cincuenta veces por página**. Sobre unos apuntes que hay que estudiar, eso deja
de ser un fondo y pasa a ser ruido encima del texto, por tenue que sea cada copia.

| | Antes | Ahora |
|---|---|---|
| Baldosa (DNI de 9 caracteres) | 356 × 165 px | 960 × 480 px |
| Marcas por hoja | **51,5** | **6,6** |
| Con un nombre largo (38 caracteres) | 17,4 | 5,5 |

La densidad pasa a ser una decisión propia y deja de depender del largo del
texto: **una marca por cada cuadro de 480 px**. El largo sólo interviene si no
cabe —un patrón SVG recorta lo que se sale de su baldosa, y media marca es peor
que ninguna—, así que un nombre largo ensancha el cuadro y salen aún menos.

La geometría se muda a `pdfMarkTile`, en `pdf-mark.js`: ese módulo existe
justamente para poder probar esta decisión sin navegador. Tres pruebas nuevas
fijan la banda de **4 a 9 marcas por hoja**, que la densidad no la decida la
etiqueta, y que las dos filas de la baldosa no queden alineadas en columnas.

La opacidad se queda como está (`.10`, el suelo de la banda). Ahora hay **dos
mandos y están documentados como tales** en `arquitectura.md`: cuánto se ve
(`--pdf-mark-alpha`) y cada cuánto se repite (`pdfMarkTile`).

**Qué no cambia:** sigue sin ser una marca forense y atribuye lo mismo que antes
—una foto de la pantalla, nunca una filtración del fichero—. Con seis marcas
repartidas en diagonal, cualquier foto de la hoja sigue llevando la identidad
dentro; lo que se pierde es el recorte muy cerrado de un párrafo suelto. Es la
contrapartida buscada: el documento se estudia.

Sólo visor. No toca material, colecciones ni nada ya desplegado en Moodle.

`npm run lint` limpio · `npm test` **370** (3 nuevas) · 0 fallos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhz6ESHu8yXA2uVFWfWyGt
