### PR TITLE
Informe de seguimiento: el nombre del alumno, el árbol carpeta>colección>materiales, la consola de admin y el contrato OpenAPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ sueltos. Antes de tocar nada:
 |---|---|
 | [`docs/README.md`](docs/README.md) | **EMPIEZA AQUÍ**: índice, estado del proyecto, hoja de ruta, limitaciones |
 | [`docs/arquitectura.md`](docs/arquitectura.md) | Vista general, árbol de medios, camino de un visionado y de una subida, modelo de datos, endpoints, modelo de seguridad |
-| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…030: por qué cada decisión y cómo revertirla |
+| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…031: por qué cada decisión y cómo revertirla |
 | [`docs/seguridad.md`](docs/seguridad.md) | Estado de seguridad vigente: qué protege cada capa, dónde está cada hallazgo, límites aceptados y secretos permanentes |
 | [`docs/desarrollo.md`](docs/desarrollo.md) | Entorno, tests, convenciones, trampas, flujo de Git |
 | [`docs/moodle-setup.md`](docs/moodle-setup.md) | Alta de la herramienta en Moodle (6 pasos) |
@@ -210,6 +210,9 @@ src/routes/     HTTP: videos, documents, collections, materials, folders, hls,
                 imports.js reparte un árbol de carpetas y decide alta o revisión
                 telemetry.js y reports.js son la capa docente: beats del visor e
                 informe del curso; reports-api.js la expone en sólo lectura
+                openapi.js sirve el contrato y su lector (/api/v1/docs)
+src/api/        openapi.json: el contrato de /api/v1, escrito a mano. Vive aquí y
+                no en docs/ porque .dockerignore excluye docs/ de la imagen
 src/services/   SQL y transacciones; nada de HTTP aquí
                 sharing.js concentra el filtro «propio o compartido»
                 import-plan.js es puro: qué se importa, dónde cae y con qué título
@@ -217,9 +220,12 @@ src/services/   SQL y transacciones; nada de HTTP aquí
                 que hacen revocable un visionado y verificable una colocación
                 course-report.js arma el informe del curso; viewing-stats.js y
                 reading-stats.js acumulan la telemetría (fail-open, ADR-030)
+                report-tree.js es puro: el informe con la forma de la biblioteca
+                (carpeta > colección > materiales), con folder-paths.js (ADR-031)
 src/security/   frame-ancestors, la IP real del cliente tras un CDN y el
                 origen público cuando la herramienta responde por varios nombres
-src/admin/      consola: alta de instancias e inventario de contenido por aula
+src/admin/      consola: alta de instancias, inventario de contenido por aula y
+                reports.js, el seguimiento de alumnos de toda la instancia
 src/media/      storage (rutas), upload (streaming), transcode, pdf, playlist,
                 watermark, signing (secure_link), reconcile
 src/queue/      cola Postgres con lease, heartbeat y reaper (vídeo y PDF)

--- a/README.en.md
+++ b/README.en.md
@@ -316,7 +316,7 @@ All reference documentation is in Spanish.
 |---|---|
 | 🧭 [`docs/README.md`](docs/README.md) | **Documentation index, project status and roadmap** |
 | 🏗️ [`docs/arquitectura.md`](docs/arquitectura.md) | Flows, data model, endpoints, security model |
-| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…030: why each decision, and how to reverse it |
+| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…031: why each decision, and how to reverse it |
 | 🔒 [`docs/seguridad.md`](docs/seguridad.md) | **Current security state**: layers, findings, accepted limits, permanent secrets |
 | 💻 [`docs/desarrollo.md`](docs/desarrollo.md) | **Developer guide**: environment, tests, conventions, debugging |
 | 🎓 [`docs/moodle-setup.md`](docs/moodle-setup.md) | Registering the tool in Moodle, in six steps, with troubleshooting |

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ capa por capa— en [`docs/arquitectura.md`](docs/arquitectura.md).
 |---|---|
 | 🧭 [`docs/README.md`](docs/README.md) | **Índice de la documentación, estado del proyecto y hoja de ruta** |
 | 🏗️ [`docs/arquitectura.md`](docs/arquitectura.md) | Flujos, modelo de datos, endpoints, modelo de seguridad |
-| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…030: por qué cada decisión y cómo revertirla |
+| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…031: por qué cada decisión y cómo revertirla |
 | 🔒 [`docs/seguridad.md`](docs/seguridad.md) | **Estado de seguridad vigente**: capas, hallazgos, límites aceptados y secretos permanentes |
 | 💻 [`docs/desarrollo.md`](docs/desarrollo.md) | **Guía para desarrolladores**: entorno, tests, convenciones, depuración |
 | 🎓 [`docs/moodle-setup.md`](docs/moodle-setup.md) | Alta de la herramienta en Moodle, en seis pasos, con diagnóstico |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | Documento | Qué resuelve |
 |---|---|
 | [`arquitectura.md`](arquitectura.md) | Vista general, árbol de medios, el camino de un visionado y el de una subida, modelo de datos, tabla de endpoints, modelo de seguridad capa por capa |
-| [`decisiones.md`](decisiones.md) | ADR-001…030. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
+| [`decisiones.md`](decisiones.md) | ADR-001…031. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
 | [`seguridad.md`](seguridad.md) | **Estado de seguridad vigente**: qué protege cada capa, dónde está cada hallazgo, los límites que hay que aceptar por escrito y qué secretos son permanentes |
 
 ### Para trabajar en él
@@ -38,7 +38,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | [`desarrollo.md`](desarrollo.md) | **Guía del desarrollador**: entorno, tests, convenciones, depuración, flujo de Git |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Cómo abrir un PR y qué se espera de él |
 | [`../.github/README.md`](../.github/README.md) | **Manual del pipeline**: el día a día en cinco pasos, qué hace cada workflow y cómo se promociona a producción |
-| [`api-migracion-contenido.md`](api-migracion-contenido.md) | API resumible para migrar vídeos y PDF desde Postman o shell, con sus estados y garantías |
+| [`api-migracion-contenido.md`](api-migracion-contenido.md) | Las dos APIs de `/api/v1`: migración resumible de vídeos y PDF, e informes de seguimiento de sólo lectura. El contrato OpenAPI lo sirve la propia herramienta en `/api/v1/openapi.json` |
 
 ### Para desplegarlo
 
@@ -83,8 +83,8 @@ El manual completo, con los errores que verás y qué significan, está en
 ## Estado del proyecto
 
 **Producción: `v1.0.8`** (20 de agosto de 2026) · 21 migraciones en `test` ·
-**428 pruebas unitarias** (419 pasan, 9 se saltan sin las herramientas de la imagen del
-worker) y **172 de integración** contra PostgreSQL real · `npm audit` en 0.
+**448 pruebas unitarias** (439 pasan, 9 se saltan sin las herramientas de la imagen del
+worker) y **176 de integración** contra PostgreSQL real · `npm audit` en 0.
 
 El sistema está **en uso, sirviendo material real**. Lo que sigue no es una lista de
 funcionalidad por construir, sino el mapa de lo que hay:
@@ -121,6 +121,15 @@ donde está desplegado el material ([ADR-023](decisiones.md)), y el mismo inform
 pedir por API para cruzarlo con una herramienta externa. El tiempo visto y las páginas
 leídas los manda el visor y son **orientativos**: son telemetría docente fail-open, no el
 registro forense, que sigue intacto ([ADR-030](decisiones.md)).
+
+El mismo informe se lee además **con la forma de la biblioteca** —carpeta > carpeta > …
+> colección > materiales, con el avance en cada hoja y la suma en cada carpeta—, tanto por
+API como en la consola de administración, que puede buscar a un alumno por su nombre de
+usuario de Moodle y ver su avance en todas las aulas. La ruta de carpetas es organización
+privada de su profesor: a un compañero de aula se le enseña el material, no cómo lo tiene
+ordenado su dueño ([ADR-031](decisiones.md)). El contrato de integración es un OpenAPI 3.1
+servido por la propia herramienta en `/api/v1/openapi.json`, con lector y probador en
+`/api/v1/docs`.
 
 **Operación**: la IP real del alumno se recupera tras un CDN ([ADR-019](decisiones.md)) —
 sin eso, todos los visionados quedaban registrados con la IP del borde de Cloudflare, que

--- a/docs/api-migracion-contenido.md
+++ b/docs/api-migracion-contenido.md
@@ -1,8 +1,21 @@
-# API de migración de contenido
+# APIs de integración (`/api/v1`)
+
+Dos APIs bajo el mismo prefijo y con **tokens distintos y no intercambiables**:
+la de **contenido**, que escribe (este documento, de aquí abajo), y la de
+**[informes](#api-de-informes)**, que sólo lee.
+
+## API de contenido
 
 La API `/api/v1` permite importar vídeos y PDF desde Postman o un script sin
 crear un segundo pipeline. Usa la misma recepción fragmentada, las mismas
 validaciones, las mismas tablas de trabajo y el mismo worker que la interfaz.
+
+> [!TIP]
+> El contrato completo de `/api/v1` —ésta y la [API de informes](#api-de-informes)—
+> está en [`src/api/openapi.json`](../src/api/openapi.json) (OpenAPI 3.1). La propia
+> herramienta lo sirve en `GET /api/v1/openapi.json`, recortado a las APIs que ese
+> despliegue tiene activas, y lo enseña con un probador en `GET /api/v1/docs`.
+> Vive en `src/` y no aquí porque `.dockerignore` excluye `docs/` de la imagen.
 
 > [!WARNING]
 > `CONTENT_API_TOKEN` es una **credencial administrativa potente**: quien la tenga puede
@@ -214,3 +227,81 @@ son `ready`, `failed` o `cancelled`. No lances varios contenedores `worker` si b
 procesamiento global estrictamente secuencial: cada proceso respeta concurrencia uno,
 pero dos réplicas pueden reclamar trabajos distintos gracias a `SKIP LOCKED`. Las cuotas
 de jobs se calculan en PostgreSQL y no se eluden levantando más procesos web.
+
+## API de informes
+
+Segunda API bajo el mismo prefijo, **de sólo lectura** y con **token propio**:
+`REPORTS_API_TOKEN`. Es la que se integra con una herramienta externa de
+seguimiento de alumnos. No es intercambiable con `CONTENT_API_TOKEN` —ese
+escribe eligiendo `owner_sub`, es decir, suplantando a cualquier profesor— y la
+aplicación **rechaza el arranque si los dos coinciden**.
+
+```sh
+REPORTS_API_TOKEN=<openssl rand -hex 32>
+REPORTS_API_ALLOWED_PLATFORM_IDS=<uuid-plataforma-1>,<uuid-plataforma-2>
+```
+
+Con el token vacío, estas rutas responden `404`. En producción exige 32
+caracteres como mínimo y la lista de plataformas no puede estar vacía.
+
+| Método | Ruta | Qué devuelve |
+|---|---|---|
+| GET | `/api/v1/reports/courses?platformId=` | Aulas conocidas de esa instancia (tope 200) |
+| GET | `/api/v1/reports/courses/{contextId}?platformId=` | El informe completo del aula: el mismo JSON que ve el profesor |
+| GET | `/api/v1/reports/students?platformId=&identity=` | El avance de un alumno **por su username de Moodle**, en cada aula donde tenga rastro (tope 20) |
+
+La plataforma viaja por query y no por cabecera: aquí no hay sesión LTI de la
+que sacarla. Ni `ip` ni `user_agent` salen por esta API (ADR-030); sí
+`userName` y `userIdentity`, que son justo la clave del cruce.
+
+### El informe agregado de un alumno
+
+`GET /api/v1/reports/students` es lo que responde «¿por dónde va este alumno?».
+Cada entrada trae, además de la matriz plana (`materials`, `activities`,
+`progress`, `timeline`), un campo **`tree`** con la forma de la biblioteca del
+profesor —carpeta > carpeta > … > colección > materiales—, el avance del alumno
+en cada hoja y la suma en cada nodo:
+
+```sh
+curl -sS "$MOODLESHIELD_URL/api/v1/reports/students?platformId=$PLATFORM_ID&identity=vsolano" \
+  -H "Authorization: Bearer $REPORTS_API_TOKEN" | jq '.students[0].tree'
+```
+
+```json
+[
+  { "type": "folder", "name": "Álgebra", "restricted": false,
+    "owner": { "sub": "profe-ana", "name": "Ana Ruiz" },
+    "summary": { "materials": 2, "accessed": 2, "sessions": 3, "downloads": 1, "percent": 42 },
+    "children": [
+      { "type": "folder", "name": "Tema 2", "children": [
+        { "type": "collection", "id": "e49879aa-…", "title": "Prácticas del Tema 2",
+          "items": [
+            { "type": "material", "kind": "video", "id": "859736f2-…",
+              "title": "Derivadas: introducción", "durationSeconds": 600,
+              "progress": { "sessions": 2, "uniqueSeconds": 372, "percent": 62,
+                            "completedAt": null, "lastAt": "2026-08-23T19:27:51.226Z" } },
+            { "type": "material", "kind": "pdf", "id": "882f58ea-…",
+              "title": "Boletín de ejercicios", "pageCount": 24,
+              "progress": { "sessions": 1, "uniquePages": 5, "percent": 21, "downloads": 1 } }
+          ] } ] } ] }
+]
+```
+
+Tres cosas que conviene tener claras al consumirlo:
+
+- **`percent: null` significa «no medido», no cero.** La telemetría de tiempo y
+  páginas es posterior al despliegue inicial; `telemetry.{opensSince,
+  videoStatsSince, pdfStatsSince}` dice desde cuándo hay dato. Pintar «0 %» sobre
+  un material que un alumno vio antes sería una acusación falsa (ADR-030).
+- **El orden de `items` es el que compuso el profesor**, no alfabético.
+- **`historical: true`** marca lo que tiene accesos pero ya no está desplegado en
+  el aula: cuenta igual, sin reinsertar nada.
+
+`GET /api/v1/reports/courses/{contextId}` devuelve el mismo `tree` pero **sin**
+`progress` en las hojas: ahí es sólo estructura, y el avance está en
+`students[].materials`, indexado por `materialId`.
+
+Un `contextId` desconocido responde **200 con un informe vacío**, y una búsqueda
+de alumno sin coincidencia devuelve `{"students": []}`. En ninguno de los dos
+casos es un 404: para un integrador «todavía no ha abierto nada» es una
+respuesta legítima.

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -306,11 +306,16 @@ Detalle y motivos en las fichas de cierre archivadas como issues:
 | GET | `/lti/config` | — | Datos de alta en Moodle |
 | POST | `/lti/deeplink/response` | token de Deep Linking | Devuelve la selección a Moodle |
 | GET/POST | `/lti/platforms` | `LTI_ADMIN_TOKEN` | Gestión de plataformas |
+| GET | `/api/v1/openapi.json` | — | **Contrato OpenAPI 3.1** de `/api/v1`, recortado a las APIs activas (404 si no hay ninguna) |
+| GET | `/api/v1/docs` | — | Lector del contrato con probador para la API de informes |
 | GET | `/api/v1/platforms` | `CONTENT_API_TOKEN` | Plataformas disponibles para una migración |
 | POST/GET/PUT/DELETE | `/api/v1/uploads…` | token + plataforma + propietario | Mismo protocolo troceado de la UI para scripts/Postman |
 | POST | `/api/v1/imports/plan` | token + plataforma + propietario | Mismo plan de importación de árboles que la biblioteca |
 | GET | `/api/v1/materials/:kind/:id` | token + plataforma + propietario | Estado de material, última revisión y trabajo |
 | GET | `/admin/platforms/:id/contenido` | consola admin | **Inventario del aula**: todo el material de todos sus profesores |
+| GET | `/admin/platforms/:id/seguimiento` | consola admin | Aulas conocidas de la instancia |
+| GET | `/admin/platforms/:id/seguimiento/curso` | consola admin | Informe de un aula (`?contextId=`) y detalle de un alumno (`&alumno=`) |
+| GET | `/admin/platforms/:id/seguimiento/alumno` | consola admin | Avance de un alumno por `?identity=` (username de Moodle), atravesando aulas |
 | GET | `/admin/platforms/:id/importar` | consola admin | Importador de la **biblioteca del centro** |
 | POST | `/admin/platforms/:id/import/imports/plan` | cookie admin + CSRF por cabecera | Plan de importación institucional |
 | — | `/admin/platforms/:id/import/uploads…` | cookie admin + CSRF por cabecera | El mismo protocolo troceado, con el propietario institucional |
@@ -517,6 +522,40 @@ cero: el informe expone `telemetry.{opensSince, videoStatsSince, pdfStatsSince}`
 justo para que la interfaz pueda distinguir «no lo vio» de «no lo medíamos».
 Ni `ip` ni `user_agent` salen de este camino: son del trazado, no del
 seguimiento, y ninguna consulta de `services/course-report.js` los selecciona.
+
+### El mismo informe con la forma de la biblioteca
+
+`activities` y `materials` responden «¿qué ha visto?»; el campo **`tree`**
+responde «¿por dónde va?», que es lo que se leía de un vistazo cuando cada
+recurso era una actividad Moodle distinta. Es la biblioteca del profesor:
+carpeta > carpeta > … > colección > materiales, con el avance del alumno en cada
+hoja y la suma en cada nodo (`summary`) cuando se pide el informe de uno solo.
+Lo monta `services/report-tree.js`, que es **puro** —recibe lo ya consultado— a
+partir de las rutas en segmentos de `services/folder-paths.js`.
+
+`tree` **se añade**; no sustituye a nada. `activities` y `materials` son contrato
+ya emitido a la herramienta externa y a la interfaz del profesor (Regla 0-bis).
+
+La ruta de carpetas tiene una frontera propia: el árbol es **organización
+privada del profesor** (ADR-016) y el informe lo ve cualquier profesor del aula
+(ADR-023). A un compañero se le enseña el material —es del curso— pero no cómo
+lo tiene ordenado su dueño: si la carpeta no está compartida, el material cuelga
+de un nodo `restricted: true` llamado «Biblioteca de …». Quien pregunta sin
+sesión LTI —la consola de administración y la API de informes, ambos secretos de
+operador— ve la ruta entera. Lo decide el parámetro `viewerSub`, que en el camino
+del profesor sale de la sesión.
+
+| Quién pregunta | Cómo | Ve la ruta de carpetas ajenas |
+|---|---|---|
+| Profesor del aula | `GET /reports/course` | Sólo las suyas y las compartidas |
+| Operador | consola `/admin/platforms/:id/seguimiento` | Sí |
+| Herramienta externa | `GET /api/v1/reports/students` | Sí |
+
+El contrato completo de esa API está en `src/api/openapi.json` y se sirve en
+`GET /api/v1/openapi.json`; `GET /api/v1/docs` lo enseña con un probador para
+las operaciones de sólo lectura. El spec no se genera —se escribe a mano— y lo
+que impide que envejezca es `test/openapi.test.js`, que compara sus rutas con
+las que los routers registran de verdad.
 
 ## Qué ve el alumno de su propia sesión
 

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -1266,3 +1266,63 @@ truco de `position=0` al terminar lo hace inservible como medida de completitud
 demás sigue igual, porque nada del camino de reproducción depende de esta capa.
 Las tablas pueden quedarse vacías sin estorbar; borrarlas es opcional y, por
 Regla 0, se documenta antes de hacerse.
+
+## ADR-031 · El informe también se lee con la forma de la biblioteca, y la ruta de carpetas es privada de su profesor
+
+**Estado**: aceptada · **Fecha**: 2026-08 · Extiende ADR-030 · Convive con ADR-016, ADR-018 y ADR-023
+
+**Contexto.** ADR-030 dejó el informe como una matriz plana: `activities` y
+`materials` responden «¿qué ha visto este alumno?». Falta la otra pregunta, la
+que el profesor se hacía de un vistazo cuando cada recurso era una actividad
+Moodle distinta y el curso se leía en orden: **«¿por dónde va?»**. Con
+colecciones y carpetas anidadas (ADR-013, ADR-016) esa lectura se perdió, y la
+herramienta externa del operador tampoco podía reconstruirla: la ruta de carpetas
+no salía por ninguna parte del informe.
+
+**Decisión.** El informe gana un campo **`tree`** con la forma de la biblioteca
+—carpeta > carpeta > … > colección > materiales—, y una vista de sólo lectura en
+la consola de administración que lo enseña por aula y por alumno.
+
+- **`tree` se añade; no sustituye a nada.** `activities` y `materials` son
+  contrato ya emitido a la herramienta externa y a la interfaz del profesor: si
+  el árbol los reemplazara, una integración escrita hoy dejaría de funcionar
+  mañana (Regla 0-bis). El árbol se monta con los mismos datos ya consultados,
+  en una función **pura** (`services/report-tree.js`), probable sin Postgres.
+- **La ruta de carpetas no es del curso, es del profesor.** El árbol es
+  organización privada (ADR-016) y el informe lo ve cualquier profesor del aula
+  (ADR-023). «Rehacer 2025» o «Borradores baja de Ana» son información del
+  claustro, no de la asignatura. A un compañero se le enseña el material —eso sí
+  es del curso— colgado de un nodo `restricted: true` («Biblioteca de …») salvo
+  que la carpeta esté compartida (ADR-018), en cuyo caso sale su ruta real. Lo
+  decide un `viewerSub` que en el camino del profesor sale **de la sesión**.
+- **El operador no tiene ese recorte.** La consola de administración y la API de
+  informes ven la ruta entera, igual que `/admin/platforms/:id/contenido` ya
+  enseña todo el inventario de una instancia. Son secretos de operador, no
+  sesiones de profesor.
+- **El porcentaje de un nodo es la media de los materiales CON dato.** Un
+  material sin telemetría no cuenta como 0: enseñar «0 %» de algo que no se midió
+  es la misma acusación falsa que ADR-030 se prohibió.
+- **La consola de administración es la cuarta pantalla, no una API nueva.** Los
+  datos van incrustados en el bootstrap, como el resto de la consola, y la
+  autenticación es su cookie: `REPORTS_API_TOKEN` es un secreto de servidor y no
+  baja al navegador de nadie.
+- **El contrato se escribe a mano y vive en `src/`.** `src/api/openapi.json` es
+  OpenAPI 3.1 y se sirve en `GET /api/v1/openapi.json`, recortado a las APIs que
+  ese despliegue tiene activas: prometer una operación que responde 404 porque su
+  token no está puesto es peor que no documentarla. No se genera —no hay
+  decoradores ni esquemas de los que derivarlo— y no vive en `docs/`, que
+  `.dockerignore` excluye del contexto de build. Lo que impide que envejezca es
+  `test/openapi.test.js`, que compara sus rutas con las que registran los routers.
+- **El probador no es Swagger UI.** `swagger-ui-dist` son ~12 MB y sería la
+  primera dependencia de producción que existe sólo para documentar; además
+  habría que comprobar que su bundle no exige `'unsafe-eval'`, y la CSP de esta
+  aplicación es `script-src 'self'` sin excepciones (T32). `GET /api/v1/docs` lo
+  sustituye con un módulo propio, y sólo deja probar la **API de informes**: un
+  formulario que invite a pegar `CONTENT_API_TOKEN` en un navegador deja en un
+  historial ajeno una credencial que suplanta a cualquier profesor.
+
+**Cómo revertirlo.** Quitar `tree` del retorno de `buildCourseReport` y
+`getStudentCourseReport` y desmontar `/admin/platforms/:id/seguimiento` y
+`/api/v1` → `openapiRouter` en `app.js`. Nada más depende de ello: el informe
+plano, la telemetría y el registro forense siguen exactamente igual, y no hay
+ninguna migración que deshacer — el árbol se calcula, no se guarda.

--- a/docs/seguridad.md
+++ b/docs/seguridad.md
@@ -126,6 +126,21 @@ aceptarlos explícitamente.
   salen por ese camino —ninguna consulta de `services/course-report.js` los selecciona, y
   una prueba lo vigila—, y el token de informes **sólo lee** y no vale para la API de
   contenido.
+- **La consola de administración ve más que cualquier profesor** (ADR-031). Su vista de
+  seguimiento enseña el avance de **todos** los alumnos de **todas** las aulas de una
+  instancia, mientras un profesor sólo ve la suya (ADR-023). Es coherente con
+  `/admin/platforms/:id/contenido`, que ya no filtra por propietario, pero es un alcance
+  mayor sobre datos personales y entra en el mismo #65. Es de sólo lectura, va detrás de
+  la cookie de administrador y **no** deja rastro en `admin_audit_event`: la consola sólo
+  audita escrituras, y valorar si esta lectura debería auditarse es decisión del operador.
+  Lo que sí está cerrado por código: aquí tampoco salen `ip` ni `user_agent`, y
+  `REPORTS_API_TOKEN` no baja al navegador.
+- **La ruta de carpetas de un profesor no se le enseña a otro** (ADR-031). El árbol de la
+  biblioteca es organización privada (ADR-016) y sus nombres son información del claustro
+  —«Borradores baja de Ana»—, no de la asignatura. En `GET /reports/course` el material
+  ajeno cuelga de un nodo `restricted` que sólo dice de quién es, salvo que la carpeta esté
+  compartida (ADR-018). El recorte lo decide un `viewerSub` que sale de la sesión LTI, no
+  del cliente.
 - **Una imagen endurecida reduce el riesgo; no vuelve infalibles** a ffmpeg, Ghostscript,
   Node, nginx, PostgreSQL ni Moodle. Hay que mantener parches y repetir el gate en cada
   release ([#64](https://github.com/jamataran/moodleshield/issues/64)).

--- a/src/admin/reports.js
+++ b/src/admin/reports.js
@@ -1,0 +1,170 @@
+import { Router } from 'express'
+import { renderPage } from '../ui/render.js'
+import { csrfToken } from './auth.js'
+import { getPlatformById } from '../services/platforms.js'
+import {
+  findStudentCourses,
+  getCourseReport,
+  getStudentCourseReport,
+  listKnownCourses
+} from '../services/course-report.js'
+
+/**
+ * Seguimiento de alumnos en la consola de administración.
+ *
+ * Mismo servicio que ve el profesor (`services/course-report.js`) y misma
+ * herramienta externa (`routes/reports-api.js`); lo que cambia es quién
+ * pregunta. Aquí el operador ve **todas** las aulas de una instancia, igual que
+ * ya ve todo su contenido en `/contenido`, y por tanto sin el recorte de
+ * carpetas privadas que sí se le aplica a un profesor (ADR-016): `viewerSub`
+ * queda a `null` a propósito.
+ *
+ * Sólo GET y sólo lectura: no hace falta CSRF, y la autenticación es la cookie
+ * de administrador que ya resolvió `requireAdmin` antes de llegar aquí. El
+ * `REPORTS_API_TOKEN` no pinta nada en esta superficie —es un secreto de
+ * servidor y jamás debe bajar al navegador.
+ *
+ * Los datos van incrustados en el bootstrap, como el resto de la consola: no
+ * hay `fetch`, así que tampoco hay una API nueva que proteger.
+ */
+export const adminReportsRouter = Router({ mergeParams: true })
+
+/** Techo del texto libre que Moodle usa como identificador de curso. */
+const MAX_CONTEXT = 512
+const MAX_SUB = 255
+
+async function plataforma (req, res) {
+  const platform = await getPlatformById(req.params.id)
+  // Una instancia deshabilitada conserva su histórico: se puede consultar.
+  if (!platform) {
+    res.sendStatus(404)
+    return null
+  }
+  return platform
+}
+
+function marco (req, platform, extra) {
+  return {
+    platform: { id: platform.id, name: platform.name, issuer: platform.issuer },
+    logoutCsrf: csrfToken(req.adminSession, 'POST', '/logout'),
+    ...extra
+  }
+}
+
+/**
+ * La matriz del curso puede tener 500 alumnos × 200 materiales: mandar cada
+ * celda al navegador para pintar cinco columnas sería mover megabytes de datos
+ * personales sin motivo. El detalle completo viaja sólo en la vista de un
+ * alumno, que es una fila.
+ */
+function resumeAlumno (alumno) {
+  return {
+    sub: alumno.sub,
+    name: alumno.name,
+    identity: alumno.identity,
+    opens: alumno.opens,
+    firstAt: alumno.firstAt,
+    lastAt: alumno.lastAt,
+    accessed: alumno.materials.filter((entrada) => entrada.sessions > 0).length,
+    sessions: alumno.materials.reduce((total, entrada) => total + (entrada.sessions ?? 0), 0),
+    downloads: alumno.materials.reduce((total, entrada) => total + (entrada.downloads ?? 0), 0)
+  }
+}
+
+/** Índice: las aulas que esta herramienta conoce de la instancia. */
+adminReportsRouter.get('/', async (req, res, next) => {
+  try {
+    const platform = await plataforma(req, res)
+    if (!platform) return
+    const courses = await listKnownCourses({ platformId: platform.id })
+    res.type('html').send(await renderPage('admin/platform-report.html', {
+      bootstrap: marco(req, platform, { view: 'courses', courses })
+    }))
+  } catch (err) {
+    next(err)
+  }
+})
+
+/**
+ * Informe de un aula, y —con `alumno`— el detalle de uno solo.
+ *
+ * El `contextId` viaja por query y no como segmento de ruta: es texto libre de
+ * Moodle de hasta 512 caracteres y en la ruta obligaría a codificarlo en los
+ * dos extremos.
+ */
+adminReportsRouter.get('/curso', async (req, res, next) => {
+  try {
+    const platform = await plataforma(req, res)
+    if (!platform) return
+    const contextId = String(req.query.contextId ?? '').trim()
+    if (!contextId || contextId.length > MAX_CONTEXT) return res.sendStatus(404)
+    const sub = String(req.query.alumno ?? '').trim()
+    if (sub.length > MAX_SUB) return res.sendStatus(404)
+
+    if (sub) {
+      const detalle = await getStudentCourseReport({ platformId: platform.id, contextId, sub })
+      // 404 y no 403: un alumno que no aparece en ese aula no existe para este
+      // informe, igual que en el camino del profesor.
+      if (!detalle) return res.sendStatus(404)
+      return res.type('html').send(await renderPage('admin/platform-report.html', {
+        bootstrap: marco(req, platform, { view: 'student', report: detalle })
+      }))
+    }
+
+    const report = await getCourseReport({ platformId: platform.id, contextId })
+    res.type('html').send(await renderPage('admin/platform-report.html', {
+      bootstrap: marco(req, platform, {
+        view: 'course',
+        report: {
+          course: report.course,
+          telemetry: report.telemetry,
+          tree: report.tree,
+          totals: report.totals,
+          students: report.students.map(resumeAlumno)
+        }
+      })
+    }))
+  } catch (err) {
+    next(err)
+  }
+})
+
+/**
+ * Un alumno por su username de Moodle, atravesando aulas.
+ *
+ * Es la misma pregunta que responde `GET /api/v1/reports/students`, con la
+ * misma forma —incluido el árbol carpeta > colección > materiales—, pero en
+ * pantalla y con la cookie del administrador en vez de con un token.
+ */
+adminReportsRouter.get('/alumno', async (req, res, next) => {
+  try {
+    const platform = await plataforma(req, res)
+    if (!platform) return
+    const identity = String(req.query.identity ?? '').trim()
+    const sub = String(req.query.sub ?? '').trim()
+    if ((!identity && !sub) || identity.length > MAX_SUB || sub.length > MAX_SUB) {
+      return res.sendStatus(404)
+    }
+
+    const apariciones = await findStudentCourses({
+      platformId: platform.id, identity: identity || null, sub: sub || null, limit: 20
+    })
+    const reports = []
+    for (const aparicion of apariciones) {
+      const detalle = await getStudentCourseReport({
+        platformId: platform.id, contextId: aparicion.contextId, sub: aparicion.sub
+      })
+      if (detalle) reports.push(detalle)
+    }
+
+    res.type('html').send(await renderPage('admin/platform-report.html', {
+      bootstrap: marco(req, platform, {
+        view: 'search',
+        query: { identity: identity || null, sub: sub || null },
+        reports
+      })
+    }))
+  } catch (err) {
+    next(err)
+  }
+})

--- a/src/admin/routes.js
+++ b/src/admin/routes.js
@@ -26,6 +26,7 @@ import {
   issueLoginCsrf,
   verifyLoginCsrf
 } from './auth.js'
+import { adminReportsRouter } from './reports.js'
 import {
   endpointWarnings,
   normalizePlatformInput,
@@ -407,6 +408,9 @@ importScope.post('/done', async (req, res, next) => {
 })
 
 adminRouter.use('/platforms/:id/import', requireImportScope, requireImportCsrf, importScope)
+
+// Antes de `/platforms/:id`, que si no se traga `/platforms/:id/seguimiento`.
+adminRouter.use('/platforms/:id/seguimiento', adminReportsRouter)
 
 adminRouter.get('/platforms/:id', async (req, res, next) => {
   try {

--- a/src/api/openapi.json
+++ b/src/api/openapi.json
@@ -1,0 +1,734 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MoodleShield · API de integración",
+    "version": "1.0.0",
+    "summary": "Seguimiento de alumnos (sólo lectura) y migración de contenido.",
+    "description": "Dos APIs distintas bajo el mismo prefijo `/api/v1`, con **tokens distintos y no intercambiables**.\n\n- **Informes** (`/api/v1/reports`): sólo lectura. Token `REPORTS_API_TOKEN`. Es la que se integra con una herramienta externa de seguimiento de alumnos.\n- **Contenido** (el resto): escritura. Token `CONTENT_API_TOKEN`, que permite subir material **suplantando a cualquier profesor** de las plataformas autorizadas. Quien sólo consulta avances no debe sostener ese secreto; la aplicación rechaza el arranque si los dos tokens coinciden.\n\nCon un token sin configurar, su superficie responde **404**, no 401: una API deshabilitada no se anuncia. Un 404 en estas rutas puede significar «no existe» o «no está activada».\n\nNi `ip` ni `user_agent` salen jamás por la API de informes: son del registro forense, no del seguimiento docente (ADR-030).",
+    "contact": { "name": "MoodleShield", "url": "https://github.com/jamataran/moodleshield" },
+    "license": { "name": "Consultar el repositorio", "identifier": "MIT" }
+  },
+  "servers": [{ "url": "/", "description": "Esta instancia" }],
+  "tags": [
+    { "name": "Informes", "description": "Seguimiento de alumnos. Sólo lectura, token propio." },
+    { "name": "Contenido", "description": "Migración de vídeo y PDF. Escritura." }
+  ],
+  "components": {
+    "securitySchemes": {
+      "reportsApiToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "`REPORTS_API_TOKEN`. Sólo lectura. NO es intercambiable con `contentApiToken`."
+      },
+      "contentApiToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "`CONTENT_API_TOKEN`. Credencial administrativa: escribe eligiendo `owner_sub`. NO es intercambiable con `reportsApiToken`."
+      },
+      "platformIdHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-MoodleShield-Platform-Id",
+        "description": "UUID de la instancia Moodle (`lti_platform.id`)."
+      },
+      "ownerSubHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-MoodleShield-Owner-Sub",
+        "description": "`sub` LTI del profesor propietario. El mismo con el que abre su biblioteca."
+      }
+    },
+    "parameters": {
+      "platformId": {
+        "name": "platformId",
+        "in": "query",
+        "required": true,
+        "description": "UUID de la instancia Moodle. Sin sesión LTI no hay otra forma de acotarla.",
+        "schema": { "type": "string", "format": "uuid" }
+      },
+      "ownerName": {
+        "name": "X-MoodleShield-Owner-Name",
+        "in": "header",
+        "required": false,
+        "description": "Nombre visible del profesor. No autoriza nada; sólo se guarda para mostrarlo.",
+        "schema": { "type": "string", "maxLength": 300 }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "El bearer falta o no es el de esta API.",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      },
+      "Forbidden": {
+        "description": "El token es válido pero no está autorizado para esa plataforma.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" },
+            "example": { "error": "El token de informes no está autorizado para esta plataforma", "code": "reports_api_platform_not_allowed" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "No existe — **o la API está deshabilitada** porque su token no está configurado.",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      },
+      "BadRequest": {
+        "description": "Parámetro ausente, mal formado o demasiado largo.",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string", "description": "Mensaje en español, para una persona." },
+          "code": { "type": "string", "description": "Código estable, cuando lo hay. Es lo que conviene mirar desde un programa." }
+        },
+        "required": ["error"]
+      },
+      "Course": {
+        "type": "object",
+        "description": "Un aula de Moodle. `contextId` es el identificador del curso en el `id_token`.",
+        "properties": {
+          "contextId": { "type": "string" },
+          "title": { "type": ["string", "null"], "description": "Null mientras ningún launch haya traído el título." },
+          "label": { "type": ["string", "null"] },
+          "firstSeenAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastSeenAt": { "type": ["string", "null"], "format": "date-time" }
+        },
+        "required": ["contextId"]
+      },
+      "CourseListItem": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Course" },
+          {
+            "type": "object",
+            "properties": {
+              "activities": { "type": "integer", "description": "Actividades desplegadas y no revocadas." },
+              "lastActivityAt": { "type": ["string", "null"], "format": "date-time" }
+            }
+          }
+        ]
+      },
+      "Telemetry": {
+        "type": "object",
+        "description": "Desde cuándo hay telemetría de cada tipo. Null = nunca la ha habido.\n\nEs lo que permite pintar «sin datos» en vez de «0 min» sobre un material que un alumno vio antes de este despliegue: enseñar un cero sería una acusación falsa.",
+        "properties": {
+          "opensSince": { "type": ["string", "null"], "format": "date-time" },
+          "videoStatsSince": { "type": ["string", "null"], "format": "date-time" },
+          "pdfStatsSince": { "type": ["string", "null"], "format": "date-time" }
+        }
+      },
+      "Owner": {
+        "type": "object",
+        "description": "Profesor propietario del material.",
+        "properties": {
+          "sub": { "type": ["string", "null"] },
+          "name": { "type": ["string", "null"] }
+        }
+      },
+      "Material": {
+        "type": "object",
+        "description": "Un material medible. Un vídeo trae `durationSeconds`; un PDF, `pageCount`.",
+        "properties": {
+          "kind": { "type": "string", "enum": ["video", "pdf"] },
+          "id": { "type": "string", "format": "uuid", "description": "UUID lógico: el que Moodle lleva incrustado. No cambia jamás." },
+          "title": { "type": ["string", "null"] },
+          "durationSeconds": { "type": ["number", "null"] },
+          "pageCount": { "type": ["integer", "null"] },
+          "activityKey": { "type": "string", "description": "Actividad de la que cuelga: `<kind>:<uuid>`." },
+          "activityTitle": { "type": ["string", "null"] },
+          "folderId": { "type": ["string", "null"], "format": "uuid" },
+          "owner": { "$ref": "#/components/schemas/Owner" }
+        }
+      },
+      "Activity": {
+        "type": "object",
+        "description": "Una actividad Moodle. Una colección es UNA actividad con N materiales dentro (ADR-013).",
+        "properties": {
+          "key": { "type": "string", "description": "`<kind>:<uuid>`" },
+          "kind": { "type": "string", "enum": ["video", "pdf", "collection"] },
+          "id": { "type": "string", "format": "uuid" },
+          "title": { "type": ["string", "null"] },
+          "placementId": { "type": ["string", "null"], "format": "uuid" },
+          "resourceLinkId": { "type": ["string", "null"] },
+          "placedAt": { "type": ["string", "null"], "format": "date-time" },
+          "historical": {
+            "type": "boolean",
+            "description": "True = tiene accesos registrados pero ningún despliegue vivo lo explica: actividades anteriores a la migración 014, o material retirado del aula. Cuenta igual; nadie va a reinsertar lo que ya funciona."
+          },
+          "durationSeconds": { "type": ["number", "null"] },
+          "pageCount": { "type": ["integer", "null"] },
+          "folderId": { "type": ["string", "null"], "format": "uuid" },
+          "owner": { "$ref": "#/components/schemas/Owner" },
+          "items": {
+            "type": "array",
+            "description": "Elementos de la colección, en el orden que compuso el profesor. Vacío si no es colección.",
+            "items": { "$ref": "#/components/schemas/Material" }
+          }
+        }
+      },
+      "MaterialProgress": {
+        "type": "object",
+        "description": "Lo que un alumno ha hecho con un material.\n\nConviven columnas de vídeo y de PDF en un mismo objeto: las que no apliquen llegan a `null`. **Nunca se devuelve `oneOf`**: el objeto viene siempre completo.\n\n`sessions`, `events`, `downloads` y las fechas salen del registro forense y son dato duro. `watchedSeconds`, `uniqueSeconds`, `uniquePages` y `percent` los manda el visor del alumno: son orientativos y falseables dentro de los topes por beat (ADR-030).",
+        "properties": {
+          "materialId": { "type": "string", "format": "uuid" },
+          "kind": { "type": "string", "enum": ["video", "pdf"] },
+          "sessions": { "type": "integer", "description": "Sesiones LTI distintas en las que tocó el material." },
+          "events": { "type": "integer", "description": "Peticiones registradas. Mayor que `sessions` cuando repite." },
+          "downloads": { "type": "integer", "description": "Descargas de la copia sellada. Sólo PDF." },
+          "firstAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastAt": { "type": ["string", "null"], "format": "date-time" },
+          "watchedSeconds": { "type": ["number", "null"], "description": "Suma de deltas: cuenta las repeticiones." },
+          "uniqueSeconds": { "type": ["number", "null"], "description": "Segundos DISTINTOS del vídeo. Es el numerador de `percent`." },
+          "maxPositionSeconds": { "type": ["number", "null"] },
+          "completedAt": { "type": ["string", "null"], "format": "date-time", "description": "Primera vez que alcanzó el 90 %. No se mueve después." },
+          "uniquePages": { "type": ["integer", "null"] },
+          "maxPage": { "type": ["integer", "null"] },
+          "readSeconds": { "type": ["number", "null"], "description": "Sólo cuenta con la pestaña visible." },
+          "percent": { "type": ["integer", "null"], "description": "0-100. **Null = no medido**, que no es lo mismo que cero." },
+          "durationSeconds": { "type": ["number", "null"] },
+          "pageCount": { "type": ["integer", "null"] }
+        }
+      },
+      "ActivityProgress": {
+        "type": "object",
+        "description": "Aperturas de la actividad: entrar sin reproducir también es seguimiento.",
+        "properties": {
+          "key": { "type": "string" },
+          "opens": { "type": "integer" },
+          "firstAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastAt": { "type": ["string", "null"], "format": "date-time" }
+        }
+      },
+      "Student": {
+        "type": "object",
+        "properties": {
+          "sub": { "type": "string", "description": "`sub` LTI. Opaco y estable." },
+          "name": { "type": ["string", "null"], "description": "Null si Moodle no comparte el nombre por su configuración de privacidad." },
+          "identity": { "type": ["string", "null"], "description": "Username de Moodle. Es la clave del cruce con una herramienta externa." },
+          "opens": { "type": "integer" },
+          "firstAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastAt": { "type": ["string", "null"], "format": "date-time" },
+          "activities": { "type": "array", "items": { "$ref": "#/components/schemas/ActivityProgress" } },
+          "materials": { "type": "array", "items": { "$ref": "#/components/schemas/MaterialProgress" } }
+        }
+      },
+      "TreeSummary": {
+        "type": "object",
+        "description": "Suma de todo lo que cuelga del nodo. `percent` es la media de los materiales CON dato: uno sin telemetría no cuenta como 0.",
+        "properties": {
+          "materials": { "type": "integer" },
+          "accessed": { "type": "integer" },
+          "sessions": { "type": "integer" },
+          "downloads": { "type": "integer" },
+          "lastAt": { "type": ["string", "null"], "format": "date-time" },
+          "percent": { "type": ["integer", "null"] }
+        }
+      },
+      "TreeNode": {
+        "description": "El informe con la forma de la biblioteca: carpeta > carpeta > … > colección > materiales.\n\nSe **añade** a `activities` y `materials`, que siguen saliendo tal cual.",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TreeFolder" },
+          { "$ref": "#/components/schemas/TreeCollection" },
+          { "$ref": "#/components/schemas/TreeMaterial" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "folder": "#/components/schemas/TreeFolder",
+            "collection": "#/components/schemas/TreeCollection",
+            "material": "#/components/schemas/TreeMaterial"
+          }
+        }
+      },
+      "TreeFolder": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "folder" },
+          "key": { "type": "string" },
+          "id": { "type": ["string", "null"], "format": "uuid", "description": "Null en los nodos sintéticos «Sin carpeta» y «Biblioteca de …»." },
+          "name": { "type": "string" },
+          "owner": { "$ref": "#/components/schemas/Owner" },
+          "restricted": {
+            "type": "boolean",
+            "description": "True = la ruta real se ha ocultado porque la carpeta es organización privada de otro profesor y no está compartida (ADR-016). El material sí sale: lo que no sale es cómo lo tiene ordenado su dueño.\n\nPor esta API **siempre es false**: el token de informes es un secreto de operador, con el mismo alcance que la consola de administración."
+          },
+          "children": { "type": "array", "items": { "$ref": "#/components/schemas/TreeNode" } },
+          "summary": { "$ref": "#/components/schemas/TreeSummary" }
+        },
+        "required": ["type", "key", "name", "children"]
+      },
+      "TreeCollection": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "collection" },
+          "key": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "title": { "type": ["string", "null"] },
+          "owner": { "$ref": "#/components/schemas/Owner" },
+          "historical": { "type": "boolean" },
+          "items": {
+            "type": "array",
+            "description": "En el orden que compuso el profesor, no alfabético.",
+            "items": { "$ref": "#/components/schemas/TreeMaterial" }
+          },
+          "summary": { "$ref": "#/components/schemas/TreeSummary" }
+        },
+        "required": ["type", "key", "id", "items"]
+      },
+      "TreeMaterial": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "material" },
+          "key": { "type": "string" },
+          "kind": { "type": "string", "enum": ["video", "pdf"] },
+          "id": { "type": "string", "format": "uuid" },
+          "title": { "type": ["string", "null"] },
+          "durationSeconds": { "type": ["number", "null"] },
+          "pageCount": { "type": ["integer", "null"] },
+          "historical": { "type": "boolean" },
+          "progress": {
+            "description": "Sólo en el árbol de UN alumno. Null = no lo ha tocado. Ausente en el árbol del aula, que es sólo estructura.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/MaterialProgress" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "required": ["type", "key", "kind", "id"]
+      },
+      "TimelineEvent": {
+        "type": "object",
+        "properties": {
+          "kind": { "type": "string", "enum": ["video", "pdf"] },
+          "materialId": { "type": "string", "format": "uuid" },
+          "collectionId": { "type": ["string", "null"], "format": "uuid" },
+          "action": { "type": "string", "enum": ["view", "read", "download", "open"] },
+          "at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "CourseReport": {
+        "type": "object",
+        "description": "El informe de un aula. Topes: 500 alumnos y 200 materiales.",
+        "properties": {
+          "course": { "$ref": "#/components/schemas/Course" },
+          "telemetry": { "$ref": "#/components/schemas/Telemetry" },
+          "activities": { "type": "array", "items": { "$ref": "#/components/schemas/Activity" } },
+          "materials": { "type": "array", "items": { "$ref": "#/components/schemas/Material" } },
+          "tree": { "type": "array", "items": { "$ref": "#/components/schemas/TreeNode" } },
+          "students": { "type": "array", "items": { "$ref": "#/components/schemas/Student" } },
+          "totals": {
+            "type": "object",
+            "properties": {
+              "students": { "type": "integer" },
+              "activities": { "type": "integer" },
+              "materials": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "StudentCourseReport": {
+        "type": "object",
+        "description": "El avance de UN alumno en UN aula, agregado y jerárquico.",
+        "properties": {
+          "sub": { "type": "string" },
+          "userName": { "type": ["string", "null"] },
+          "userIdentity": { "type": ["string", "null"], "description": "Username de Moodle." },
+          "course": { "$ref": "#/components/schemas/Course" },
+          "telemetry": { "$ref": "#/components/schemas/Telemetry" },
+          "materials": { "type": "array", "items": { "$ref": "#/components/schemas/Material" } },
+          "activities": { "type": "array", "items": { "$ref": "#/components/schemas/Activity" } },
+          "tree": {
+            "type": "array",
+            "description": "Carpeta > … > colección > materiales, con el avance de ESTE alumno en cada hoja y la suma en cada nodo. Es lo que evita cruzar `materials` por id a mano.",
+            "items": { "$ref": "#/components/schemas/TreeNode" }
+          },
+          "progress": { "$ref": "#/components/schemas/Student" },
+          "timeline": {
+            "type": "array",
+            "description": "Accesos con fecha, de más reciente a más antiguo. Tope 500.",
+            "items": { "$ref": "#/components/schemas/TimelineEvent" }
+          }
+        }
+      },
+      "Platform": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "issuer": { "type": "string" },
+          "clientId": { "type": "string" },
+          "enabled": { "type": "boolean" }
+        }
+      },
+      "UploadReservation": {
+        "type": "object",
+        "properties": {
+          "kind": { "type": "string", "enum": ["video", "pdf"] },
+          "filename": { "type": "string" },
+          "size": { "type": "integer", "description": "Tamaño total en bytes." },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "folderId": { "type": ["string", "null"], "format": "uuid" },
+          "materialId": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": "Para sustituir el fichero de un material existente **sin cambiar su UUID**: es una revisión, y las actividades Moodle ya insertadas siguen funcionando (ADR-025)."
+          }
+        },
+        "required": ["kind", "filename", "size"]
+      },
+      "UploadSession": {
+        "type": "object",
+        "properties": {
+          "uploadId": { "type": "string", "format": "uuid" },
+          "materialId": { "type": "string", "format": "uuid" },
+          "chunkBytes": { "type": "integer", "description": "Tamaño exacto de cada fragmento salvo el último." },
+          "chunkCount": { "type": "integer" },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "received": { "type": "array", "items": { "type": "integer" }, "description": "Índices ya recibidos: lo que permite reanudar." }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/v1/reports/courses": {
+      "get": {
+        "tags": ["Informes"],
+        "operationId": "listCourses",
+        "summary": "Aulas que esta herramienta conoce",
+        "description": "Las que dejaron título en un launch más las que tienen material desplegado. Tope fijo de 200; no admite paginación.",
+        "security": [{ "reportsApiToken": [] }],
+        "parameters": [{ "$ref": "#/components/parameters/platformId" }],
+        "responses": {
+          "200": {
+            "description": "Listado de aulas.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "courses": { "type": "array", "items": { "$ref": "#/components/schemas/CourseListItem" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/reports/courses/{contextId}": {
+      "get": {
+        "tags": ["Informes"],
+        "operationId": "getCourseReport",
+        "summary": "Informe completo de un aula",
+        "description": "Exactamente el mismo JSON que ve el profesor dentro de la herramienta.\n\nUn `contextId` desconocido responde **200 con un informe vacío**, no 404: para un integrador «esa aula todavía no tiene nada» es una respuesta legítima. El 404 sólo aparece si el identificador pasa de 512 caracteres.",
+        "security": [{ "reportsApiToken": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/platformId" },
+          {
+            "name": "contextId",
+            "in": "path",
+            "required": true,
+            "description": "Identificador del curso en Moodle. Texto libre, máximo 512 caracteres.",
+            "schema": { "type": "string", "maxLength": 512 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Informe del aula.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CourseReport" } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/reports/students": {
+      "get": {
+        "tags": ["Informes"],
+        "operationId": "findStudent",
+        "summary": "Avance de un alumno por su nombre de usuario de Moodle",
+        "description": "Devuelve una entrada por cada aula en la que ese alumno tiene rastro, con el informe agregado y jerárquico (`tree`) de cada una.\n\nSin coincidencia devuelve `{\"students\": []}`, **nunca 404**: para la herramienta externa «ese alumno todavía no ha abierto nada» es una respuesta legítima, no un error.\n\nTope: 20 pares (alumno, aula).",
+        "security": [{ "reportsApiToken": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/platformId" },
+          {
+            "name": "identity",
+            "in": "query",
+            "required": false,
+            "description": "Username de Moodle. Se compara sin distinguir mayúsculas. Obligatorio si no se manda `sub`.",
+            "schema": { "type": "string", "maxLength": 255 },
+            "example": "vsolano"
+          },
+          {
+            "name": "sub",
+            "in": "query",
+            "required": false,
+            "description": "`sub` LTI del alumno. Obligatorio si no se manda `identity`.",
+            "schema": { "type": "string", "maxLength": 255 }
+          },
+          {
+            "name": "contextId",
+            "in": "query",
+            "required": false,
+            "description": "Acota la búsqueda a un aula.",
+            "schema": { "type": "string", "maxLength": 512 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Una entrada por aula. Lista vacía si no hay coincidencia.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "students": { "type": "array", "items": { "$ref": "#/components/schemas/StudentCourseReport" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/platforms": {
+      "get": {
+        "tags": ["Contenido"],
+        "operationId": "listPlatforms",
+        "summary": "Instancias Moodle registradas",
+        "description": "Para averiguar el UUID que hay que poner en `X-MoodleShield-Platform-Id`. Es la única operación de contenido que no exige las cabeceras de identidad.",
+        "security": [{ "contentApiToken": [] }],
+        "responses": {
+          "200": {
+            "description": "Instancias visibles para este token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "platforms": { "type": "array", "items": { "$ref": "#/components/schemas/Platform" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/imports/plan": {
+      "post": {
+        "tags": ["Contenido"],
+        "operationId": "planImport",
+        "summary": "Repartir un árbol de directorios en carpetas y decidir alta o revisión",
+        "description": "Se le manda sólo la lista de rutas relativas y responde con el reparto resuelto. Repetir un título ya presente en la misma carpeta es una **revisión**: el UUID no se mueve y las actividades Moodle siguen abriendo (ADR-025).\n\nSe omiten ocultos (`.` inicial, `__MACOSX`, `Thumbs.db`) y lo que no sea vídeo ni PDF. Tope `MAX_IMPORT_ENTRIES` (500 por defecto); pasado, `413 too_many_entries` y no crea nada.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [{ "$ref": "#/components/parameters/ownerName" }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "parentId": { "type": ["string", "null"], "format": "uuid", "description": "Carpeta de la que cuelga el árbol. Null = raíz de la biblioteca." },
+                  "dryRun": { "type": "boolean", "description": "True resuelve el mismo reparto SIN crear ninguna carpeta." },
+                  "entries": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "path": { "type": "string", "description": "Ruta relativa con separador `/`." },
+                        "size": { "type": "integer" }
+                      },
+                      "required": ["path"]
+                    }
+                  }
+                },
+                "required": ["entries"]
+              },
+              "example": {
+                "parentId": null,
+                "dryRun": true,
+                "entries": [
+                  { "path": "Álgebra/Tema 1/clase.mp4", "size": 734003200 },
+                  { "path": "Álgebra/Tema 1/.DS_Store", "size": 6148 }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Reparto resuelto: qué se sube, dónde cae y con qué título." },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "413": { "description": "Más entradas que `MAX_IMPORT_ENTRIES`. No se ha creado nada." }
+        }
+      }
+    },
+    "/api/v1/uploads": {
+      "post": {
+        "tags": ["Contenido"],
+        "operationId": "createUpload",
+        "summary": "Reservar una sesión de subida",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [{ "$ref": "#/components/parameters/ownerName" }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UploadReservation" } } }
+        },
+        "responses": {
+          "201": {
+            "description": "Sesión reservada.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UploadSession" } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "description": "Cuota por propietario agotada. Trátalo como espera, no como error." },
+          "507": { "description": "Sin espacio: cuota de almacenamiento o disco. También es espera." }
+        }
+      }
+    },
+    "/api/v1/uploads/{uploadId}": {
+      "get": {
+        "tags": ["Contenido"],
+        "operationId": "getUpload",
+        "summary": "Estado de una sesión y fragmentos ya recibidos",
+        "description": "Permite reanudar una transferencia interrumpida durante 24 horas por defecto.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [
+          { "name": "uploadId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estado de la sesión.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UploadSession" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "delete": {
+        "tags": ["Contenido"],
+        "operationId": "cancelUpload",
+        "summary": "Cancelar una sesión y liberar su reserva",
+        "description": "**Si un `complete` falla, cancela la sesión.** Un `complete` fallido no libera la reserva, y unas pocas sesiones abandonadas agotan `MAX_ACTIVE_UPLOADS_PER_OWNER` hasta que caducan.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [
+          { "name": "uploadId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "204": { "description": "Cancelada." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/uploads/{uploadId}/chunks/{index}": {
+      "put": {
+        "tags": ["Contenido"],
+        "operationId": "putChunk",
+        "summary": "Enviar un fragmento",
+        "description": "Cuerpo binario crudo. El tamaño exacto lo dice `chunkBytes` de la reserva; el cuerpo queda limitado a `UPLOAD_CHUNK_BYTES` (16 MiB por defecto), de modo que la RAM no crece con el tamaño total.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [
+          { "name": "uploadId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
+          { "name": "index", "in": "path", "required": true, "description": "Base 0.", "schema": { "type": "integer", "minimum": 0 } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/octet-stream": { "schema": { "type": "string", "format": "binary" } } }
+        },
+        "responses": {
+          "200": { "description": "Fragmento recibido." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "413": { "description": "Fragmento mayor que `UPLOAD_CHUNK_BYTES`." }
+        }
+      }
+    },
+    "/api/v1/uploads/{uploadId}/complete": {
+      "post": {
+        "tags": ["Contenido"],
+        "operationId": "completeUpload",
+        "summary": "Reintegrar el fichero y encolar su procesado",
+        "description": "Crea, en una sola transacción, el material, su revisión y el trabajo pendiente.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [
+          { "name": "uploadId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "202": { "description": "Encolado: `status: \"queued\"`." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": { "description": "`revision_in_progress`: ese material ya tiene una candidata en cola. Un material sólo admite una a la vez." }
+        }
+      }
+    },
+    "/api/v1/materials/{kind}/{id}": {
+      "get": {
+        "tags": ["Contenido"],
+        "operationId": "getMaterialStatus",
+        "summary": "Estado de un material, su última revisión y su trabajo",
+        "description": "Para observar una importación. En una sustitución, espera además `latestRevisionPublished: true`: el material puede seguir `published: true` mientras la revisión anterior protege a las actividades existentes. Los estados terminales esperables son `ready`, `failed` o `cancelled`.",
+        "security": [{ "contentApiToken": [], "platformIdHeader": [], "ownerSubHeader": [] }],
+        "parameters": [
+          { "name": "kind", "in": "path", "required": true, "schema": { "type": "string", "enum": ["video", "pdf"] } },
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estado del material.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "material": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string", "format": "uuid" },
+                        "kind": { "type": "string", "enum": ["video", "pdf"] },
+                        "title": { "type": "string" },
+                        "status": { "type": "string" },
+                        "error": { "type": ["string", "null"] },
+                        "published": { "type": "boolean" },
+                        "latestRevisionPublished": { "type": "boolean" },
+                        "activeRevisionId": { "type": ["string", "null"], "format": "uuid" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "updatedAt": { "type": "string", "format": "date-time" }
+                      }
+                    },
+                    "revision": { "type": ["object", "null"] },
+                    "job": { "type": ["object", "null"] }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import { telemetryRouter } from './routes/telemetry.js'
 import { reportsRouter } from './routes/reports.js'
 import { contentApiRouter } from './routes/content-api.js'
 import { reportsApiRouter } from './routes/reports-api.js'
+import { openapiRouter } from './routes/openapi.js'
 import { healthRouter } from './routes/health.js'
 import { renderPage, uiDir } from './ui/render.js'
 import { adminRouter } from './admin/routes.js'
@@ -113,6 +114,9 @@ export async function createApp () {
   app.use(['/hls', '/progress', '/telemetry', '/internal'], playbackApiLimiter)
 
   app.use(healthRouter)
+  // Antes que las dos APIs: el contrato es público y no lleva token, así que no
+  // puede quedar detrás de un guardián que exija uno.
+  app.use('/api/v1', openapiRouter)
   app.use('/api/v1/reports', reportsApiRouter)
   app.use('/api/v1', contentApiRouter)
   app.use('/admin', adminRouter)

--- a/src/lti/claims.js
+++ b/src/lti/claims.js
@@ -49,6 +49,17 @@ export function hasInstructorRole (roles) {
 }
 
 /**
+ * Un dato que Moodle no manda tiene que llegar como `null`, no como ''.
+ *
+ * La diferencia importa: `''` es un valor y se cuela por cualquier `?? null`
+ * y por cualquier `a ?? b`; `null` deja que el respaldo funcione.
+ */
+export function sinVacio (valor) {
+  const texto = String(valor ?? '').trim()
+  return texto || null
+}
+
+/**
  * Aplana el id_token a la forma que usa el resto de la aplicación.
  * A partir de aquí nadie más necesita conocer las URIs de IMS.
  */
@@ -62,7 +73,12 @@ export function toLaunchContext (claims, platform) {
     deploymentId: claims[CLAIM.deploymentId],
     messageType: claims[CLAIM.messageType],
     sub: claims.sub,
-    name: claims.name ?? [claims.given_name, claims.family_name].filter(Boolean).join(' ') ?? '',
+    // Ausencia = `null`, jamás cadena vacía. Moodle omite los claims de nombre
+    // según su configuración de privacidad, y un '' atraviesa todos los
+    // `?? null` de la cadena hasta quedar guardado en los eventos: el informe
+    // de seguimiento enseñaba entonces la celda «Alumno» en blanco. Misma
+    // lección que `displayOwnerName` en services/sharing.js.
+    name: sinVacio(claims.name ?? [claims.given_name, claims.family_name].filter(Boolean).join(' ')),
     email: claims.email ?? '',
     roles,
     isInstructor: hasInstructorRole(roles),

--- a/src/lti/routes.js
+++ b/src/lti/routes.js
@@ -210,7 +210,12 @@ ltiRouter.post('/launch', async (req, res, next) => {
 
     // Identificador visible del alumno: el parámetro personalizado configurado
     // en Moodle (por defecto el username) y, si no llega, lis_person_sourcedid.
-    const identity = context.custom?.[config.lti.identityCustomParam] ?? context.lisPersonSourcedId ?? null
+    // Se descarta lo vacío, no sólo lo ausente: un parámetro personalizado mal
+    // sustituido llega como '' y con `??` se daba por bueno, dejando el
+    // respaldo sin usar y al alumno sin ningún identificador legible.
+    const identity = [context.custom?.[config.lti.identityCustomParam], context.lisPersonSourcedId]
+      .map((valor) => String(valor ?? '').trim())
+      .find(Boolean) ?? null
     logger.info(
       {
         sub: context.sub,

--- a/src/routes/openapi.js
+++ b/src/routes/openapi.js
@@ -1,0 +1,100 @@
+import { Router } from 'express'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import config from '../config.js'
+import { renderPage } from '../ui/render.js'
+import { publicOriginFor } from '../security/public-origin.js'
+
+/**
+ * El contrato de `/api/v1`, para que otra aplicación se integre sin leer código.
+ *
+ * El spec se escribe a mano en `src/api/openapi.json` y NO se genera: no hay
+ * decoradores ni validación por esquema de la que derivarlo, y un generador
+ * obligaría a anotar todas las rutas. Lo que impide que envejezca es
+ * `test/openapi.test.js`, que compara sus `paths` con las rutas que los routers
+ * registran de verdad.
+ *
+ * Vive en `src/` y no en `docs/` por un motivo prosaico: `.dockerignore` excluye
+ * `docs` del contexto de build, así que un spec ahí no existiría en test ni en
+ * producción y esta ruta serviría un 500.
+ *
+ * Se sirve **sin token**: no contiene secretos y el repositorio es público;
+ * exigirlo sólo estorbaría a quien integra. Pero respeta la propiedad de las dos
+ * APIs: con su token sin configurar, una API no se anuncia. Si no hay ninguna
+ * activa, esto también es 404; si sólo hay una, el spec sale recortado a ella.
+ */
+export const openapiRouter = Router()
+
+const specPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)), '..', 'api', 'openapi.json'
+)
+
+let cache = null
+
+async function loadSpec () {
+  if (config.isProduction && cache) return cache
+  cache = JSON.parse(await readFile(specPath, 'utf8'))
+  return cache
+}
+
+const REPORTS_PREFIX = '/api/v1/reports'
+
+/** Qué APIs están activas en ESTE despliegue. */
+export function apisActivas () {
+  return {
+    reports: Boolean(config.reportsApi.token),
+    content: Boolean(config.contentApi.token)
+  }
+}
+
+/**
+ * Recorta el spec a lo que este despliegue sirve de verdad.
+ *
+ * Prometer una operación que responde 404 porque su token no está puesto es
+ * peor que no documentarla: quien integra pierde la tarde antes de descubrirlo.
+ */
+export function specParaDespliegue (spec, { reports, content }) {
+  const paths = {}
+  for (const [ruta, item] of Object.entries(spec.paths ?? {})) {
+    const esInforme = ruta.startsWith(REPORTS_PREFIX)
+    if (esInforme ? reports : content) paths[ruta] = item
+  }
+  const tags = (spec.tags ?? []).filter((tag) =>
+    (tag.name === 'Informes' && reports) || (tag.name === 'Contenido' && content))
+  return { ...spec, paths, tags }
+}
+
+openapiRouter.get('/openapi.json', async (req, res, next) => {
+  try {
+    const activas = apisActivas()
+    if (!activas.reports && !activas.content) {
+      return res.status(404).json({ error: 'No hay ninguna API de integración activa' })
+    }
+    const spec = specParaDespliegue(await loadSpec(), activas)
+    // El origen público de verdad: la herramienta puede responder por varios
+    // nombres y el spec tiene que decir el que usó quien lo pidió.
+    spec.servers = [{ url: publicOriginFor(req), description: 'Esta instancia' }]
+    res.set('Cache-Control', 'no-cache')
+    res.json(spec)
+  } catch (err) {
+    next(err)
+  }
+})
+
+/**
+ * El lector del contrato, con probador para la API de informes.
+ *
+ * No lleva autenticación porque no enseña ningún dato: el spec es público y el
+ * token lo pone quien prueba, en su navegador y sólo en memoria. Se sirve
+ * aunque no haya ninguna API activa: entonces la página lo dice, que es más
+ * útil que un 404 sin explicación.
+ */
+openapiRouter.get('/docs', async (_req, res, next) => {
+  try {
+    res.set('Cache-Control', 'no-store')
+    res.type('html').send(await renderPage('openapi.html'))
+  } catch (err) {
+    next(err)
+  }
+})

--- a/src/routes/reports-api.js
+++ b/src/routes/reports-api.js
@@ -127,6 +127,10 @@ reportsApiRouter.get('/students', async (req, res, next) => {
         telemetry: report.telemetry,
         materials: report.materials,
         activities: report.activities,
+        // El informe agregado con la forma de la biblioteca —carpeta > … >
+        // colección > materiales—, con el avance de ESTE alumno en cada hoja y
+        // la suma en cada carpeta. Es lo que cruza la herramienta externa.
+        tree: report.tree,
         progress: report.student,
         timeline: report.timeline
       })

--- a/src/routes/reports.js
+++ b/src/routes/reports.js
@@ -35,7 +35,11 @@ reportsRouter.get('/course', requireCatalogInstructor, async (req, res, next) =>
     if (!contextId) return
     const report = await getCourseReport({
       platformId: req.session.platformId,
-      contextId
+      contextId,
+      // Quién mira: recorta del árbol los nombres de las carpetas privadas de
+      // otros profesores. El material sale igual —es del curso—; lo que no sale
+      // es cómo lo tiene organizado su dueño en su biblioteca (ADR-016).
+      viewerSub: req.session.sub
     })
     // Lleva nombres, identificadores y horas de alumnos: ni caché compartida ni
     // historial del navegador.
@@ -56,7 +60,8 @@ reportsRouter.get('/course/students/:sub', requireCatalogInstructor, async (req,
     const report = await getStudentCourseReport({
       platformId: req.session.platformId,
       contextId,
-      sub
+      sub,
+      viewerSub: req.session.sub
     })
     // 404 y no 403: un alumno de otro curso no existe para este informe.
     if (!report) return res.status(404).json({ error: 'Alumno no encontrado' })

--- a/src/services/course-report.js
+++ b/src/services/course-report.js
@@ -1,4 +1,6 @@
 import { many, one } from '../db/index.js'
+import { listFolderPaths } from './folder-paths.js'
+import { buildReportTree } from './report-tree.js'
 
 /**
  * Informe de seguimiento por curso: el sustituto del «informe completo» de
@@ -56,7 +58,10 @@ function listPlacements ({ platformId, contextId }) {
     `SELECT p.id AS placement_id, p.resource_kind AS kind, p.resource_id AS id,
             p.resource_link_id, p.created_at AS placed_at,
             COALESCE(v.title, d.title, c.title) AS title,
-            v.duration_seconds, d.page_count
+            v.duration_seconds, d.page_count,
+            COALESCE(v.folder_id, d.folder_id, c.folder_id) AS folder_id,
+            COALESCE(v.owner_sub, d.owner_sub, c.owner_sub) AS owner_sub,
+            COALESCE(v.owner_name, d.owner_name, c.owner_name) AS owner_name
        FROM resource_placement p
        LEFT JOIN video v ON p.resource_kind = 'video' AND v.id = p.resource_id
        LEFT JOIN pdf_document d ON p.resource_kind = 'pdf' AND d.id = p.resource_id
@@ -79,7 +84,10 @@ function listPlacementItems (placementIds) {
             CASE WHEN pi.video_id IS NOT NULL THEN 'video' ELSE 'pdf' END AS kind,
             COALESCE(pi.video_id, pi.document_id) AS id,
             COALESCE(v.title, d.title) AS title,
-            v.duration_seconds, d.page_count
+            v.duration_seconds, d.page_count,
+            COALESCE(v.folder_id, d.folder_id) AS folder_id,
+            COALESCE(v.owner_sub, d.owner_sub) AS owner_sub,
+            COALESCE(v.owner_name, d.owner_name) AS owner_name
        FROM resource_placement p
        JOIN resource_placement_item pi ON pi.placement_id = p.id
        JOIN content_collection_item ci
@@ -96,16 +104,21 @@ function listPlacementItems (placementIds) {
 /** Material con accesos en este curso que ningún placement vivo explica. */
 function listHistoricalMaterials ({ platformId, contextId }) {
   return many(
-    `SELECT 'video' AS kind, e.video_id AS id, max(v.title) AS title,
-            max(v.duration_seconds) AS duration_seconds, NULL::int AS page_count
+    // Agrupar por la clave primaria del material deja seleccionar sus columnas
+    // sin envolverlas en `max()`: dependencia funcional, y así no hace falta un
+    // agregado de uuid para la carpeta.
+    `SELECT 'video' AS kind, v.id AS id, v.title AS title,
+            v.duration_seconds AS duration_seconds, NULL::int AS page_count,
+            v.folder_id, v.owner_sub, v.owner_name
        FROM view_event e JOIN video v ON v.id = e.video_id
       WHERE e.platform_id = $1 AND e.context_id = $2
-      GROUP BY e.video_id
+      GROUP BY v.id
       UNION ALL
-     SELECT 'pdf', e.document_id, max(d.title), NULL::int, max(d.page_count)
+     SELECT 'pdf', d.id, d.title, NULL::numeric, d.page_count,
+            d.folder_id, d.owner_sub, d.owner_name
        FROM document_view_event e JOIN pdf_document d ON d.id = e.document_id
       WHERE e.platform_id = $1 AND e.context_id = $2
-      GROUP BY e.document_id`,
+      GROUP BY d.id`,
     [platformId, contextId]
   )
 }
@@ -113,12 +126,18 @@ function listHistoricalMaterials ({ platformId, contextId }) {
 /**
  * Alumnos del curso: quien tenga cualquier rastro en él. El profesor no genera
  * ni accesos ni aperturas (mismo criterio que el forense), así que no aparece.
+ *
+ * `NULLIF(..., '')` es la reparación en lado lectura de las filas que se
+ * escribieron con nombre vacío antes de arreglar `toLaunchContext`: `max('')`
+ * devuelve '' —Postgres ignora los NULL, no las cadenas vacías— y ese '' se
+ * colaba hasta la interfaz como si fuera un nombre. No se toca ni una fila
+ * (Regla 0): se lee bien lo que ya está escrito.
  */
 function listStudents ({ platformId, contextId, sub = null }) {
   return many(
     `SELECT t.user_sub AS sub,
-            max(t.user_name) AS name,
-            max(t.user_identity) AS identity,
+            NULLIF(max(t.user_name), '') AS name,
+            NULLIF(max(t.user_identity), '') AS identity,
             min(t.created_at) AS first_at,
             max(t.created_at) AS last_at,
             count(*) FILTER (WHERE t.origen = 'open')::int AS opens
@@ -134,7 +153,9 @@ function listStudents ({ platformId, contextId, sub = null }) {
        ) t
       WHERE $3::text IS NULL OR t.user_sub = $3
       GROUP BY t.user_sub
-      ORDER BY lower(coalesce(max(t.user_name), max(t.user_identity), t.user_sub))
+      ORDER BY lower(coalesce(NULLIF(max(t.user_name), ''),
+                              NULLIF(max(t.user_identity), ''),
+                              t.user_sub))
       LIMIT ${MAX_STUDENTS}`,
     [platformId, contextId, sub]
   )
@@ -237,8 +258,16 @@ function materialDto (row, { kind, activityKey, activityTitle }) {
       : Number(row.duration_seconds),
     pageCount: row.page_count ?? null,
     activityKey,
-    activityTitle
+    activityTitle,
+    folderId: row.folder_id ?? null,
+    owner: propietario(row)
   }
+}
+
+/** El profesor dueño del material: quien decide dónde vive en su biblioteca. */
+function propietario (row) {
+  if (!row.owner_sub && !row.owner_name) return null
+  return { sub: row.owner_sub ?? null, name: row.owner_name ?? null }
 }
 
 /**
@@ -277,6 +306,8 @@ export async function listCourseActivities ({ platformId, contextId }) {
       historical: false,
       durationSeconds: placement.duration_seconds === null ? null : Number(placement.duration_seconds),
       pageCount: placement.page_count ?? null,
+      folderId: placement.folder_id ?? null,
+      owner: propietario(placement),
       items: []
     }
     if (placement.kind === 'collection') {
@@ -327,6 +358,8 @@ export async function listCourseActivities ({ platformId, contextId }) {
       historical: true,
       durationSeconds: material.durationSeconds,
       pageCount: material.pageCount,
+      folderId: material.folderId,
+      owner: material.owner,
       items: []
     })
   }
@@ -382,10 +415,22 @@ function aplicaLecturaStats (entrada, stats, material) {
 }
 
 /**
+ * El mismo material, colgado de la biblioteca: carpeta > … > colección > vídeo.
+ *
+ * `viewerSub` es quien mira: un profesor del aula (ADR-023) no ve el nombre de
+ * las carpetas privadas de un compañero, un operador sí. Se recalcula aparte
+ * porque el árbol del alumno lleva su avance en cada hoja y el del curso no.
+ */
+function arbolDelCurso ({ platformId, activities, viewerSub, progress = null }) {
+  return listFolderPaths({ platformId, folderIds: activities.map((a) => a.folderId) })
+    .then((folderPaths) => buildReportTree({ activities, folderPaths, viewerSub, progress }))
+}
+
+/**
  * Informe completo de un curso. Un único objeto: la interfaz pinta la matriz y
  * la API externa (#79) devuelve exactamente esto.
  */
-export async function buildCourseReport ({ platformId, contextId, sub = null }) {
+export async function buildCourseReport ({ platformId, contextId, sub = null, viewerSub = null }) {
   if (!platformId || !contextId) return null
 
   const { activities, materials } = await listCourseActivities({ platformId, contextId })
@@ -474,6 +519,9 @@ export async function buildCourseReport ({ platformId, contextId, sub = null }) 
     },
     activities,
     materials,
+    // La misma información que `activities`, con la forma de la biblioteca.
+    // Se AÑADE: `activities` y `materials` son contrato ya emitido (Regla 0-bis).
+    tree: await arbolDelCurso({ platformId, activities, viewerSub }),
     students: [...filas.values()].map((fila) => ({
       sub: fila.sub,
       name: fila.name,
@@ -492,8 +540,8 @@ export async function buildCourseReport ({ platformId, contextId, sub = null }) 
   }
 }
 
-export function getCourseReport ({ platformId, contextId }) {
-  return buildCourseReport({ platformId, contextId })
+export function getCourseReport ({ platformId, contextId, viewerSub = null }) {
+  return buildCourseReport({ platformId, contextId, viewerSub })
 }
 
 /**
@@ -503,9 +551,9 @@ export function getCourseReport ({ platformId, contextId }) {
  * Devuelve `null` si ese `sub` no aparece en ESTE curso: nadie pesca alumnos de
  * otros cursos escribiendo un identificador.
  */
-export async function getStudentCourseReport ({ platformId, contextId, sub }) {
+export async function getStudentCourseReport ({ platformId, contextId, sub, viewerSub = null }) {
   if (!platformId || !contextId || !sub) return null
-  const report = await buildCourseReport({ platformId, contextId, sub })
+  const report = await buildCourseReport({ platformId, contextId, sub, viewerSub })
   const student = report?.students?.[0]
   if (!student) return null
 
@@ -535,6 +583,15 @@ export async function getStudentCourseReport ({ platformId, contextId, sub }) {
     telemetry: report.telemetry,
     activities: report.activities,
     materials: report.materials,
+    // Aquí el árbol SÍ lleva el avance en cada hoja y la suma en cada carpeta:
+    // es el informe agregado por alumno, con la forma en que el profesor
+    // organizó su material.
+    tree: await arbolDelCurso({
+      platformId,
+      activities: report.activities,
+      viewerSub,
+      progress: new Map(student.materials.map((entrada) => [entrada.materialId, entrada]))
+    }),
     student,
     timeline: timeline.map((row) => ({
       kind: row.kind,
@@ -597,7 +654,8 @@ export function findStudentCourses ({ platformId, identity = null, sub = null, c
   if (!platformId || (!identity && !sub)) return Promise.resolve([])
   return many(
     `SELECT t.user_sub AS sub, t.context_id,
-            max(t.user_name) AS name, max(t.user_identity) AS identity,
+            NULLIF(max(t.user_name), '') AS name,
+            NULLIF(max(t.user_identity), '') AS identity,
             min(t.created_at) AS first_at, max(t.created_at) AS last_at,
             count(*)::int AS events
        FROM (

--- a/src/services/folder-paths.js
+++ b/src/services/folder-paths.js
@@ -1,0 +1,55 @@
+import { many } from '../db/index.js'
+
+/**
+ * La ruta de una carpeta, en segmentos.
+ *
+ * El inventario de la consola (`platform-content.js`) ya calcula rutas, pero las
+ * devuelve concatenadas con « / »: una carpeta que se llame «Tema 3 / anexos»
+ * produce una ruta indistinguible de dos niveles. Aquí la ruta viaja como lista
+ * de `{id, name}`, que es lo único que permite montar un árbol sin adivinar
+ * dónde estaba el separador.
+ *
+ * `shared` se hereda hacia abajo igual que en la vista `catalog_folder_shared`
+ * (migración 009): una subcarpeta de una carpeta compartida está compartida.
+ * Es lo que decide si la ruta de otro profesor se le puede enseñar a un
+ * compañero de aula — el árbol es organización PRIVADA (ADR-016), y los nombres
+ * de carpeta son información del claustro, no del curso.
+ */
+
+/** Techo de profundidad: el esquema no lo impone, pero un ciclo largo sí colgaría. */
+const MAX_PROFUNDIDAD = 32
+
+/**
+ * @returns {Promise<Map<string, {id, ownerSub, ownerName, shared, segments}>>}
+ */
+export async function listFolderPaths ({ platformId, folderIds = [] }) {
+  const ids = [...new Set(folderIds.filter(Boolean))]
+  if (!platformId || ids.length === 0) return new Map()
+
+  const rows = await many(
+    `WITH RECURSIVE ruta AS (
+       SELECT f.id, f.owner_sub, f.owner_name, f.is_public AS shared,
+              ARRAY[f.id] AS ids, ARRAY[f.name] AS names, 1 AS profundidad
+         FROM catalog_folder f
+        WHERE f.platform_id = $1 AND f.parent_id IS NULL
+       UNION ALL
+       SELECT h.id, h.owner_sub, h.owner_name, (h.is_public OR r.shared),
+              r.ids || h.id, r.names || h.name, r.profundidad + 1
+         FROM catalog_folder h
+         JOIN ruta r ON h.parent_id = r.id
+        WHERE r.profundidad < ${MAX_PROFUNDIDAD}
+     )
+     SELECT id, owner_sub, owner_name, shared, ids, names
+       FROM ruta
+      WHERE id = ANY($2::uuid[])`,
+    [platformId, ids]
+  )
+
+  return new Map(rows.map((row) => [row.id, {
+    id: row.id,
+    ownerSub: row.owner_sub,
+    ownerName: row.owner_name ?? null,
+    shared: Boolean(row.shared),
+    segments: (row.ids ?? []).map((id, i) => ({ id, name: (row.names ?? [])[i] ?? null }))
+  }]))
+}

--- a/src/services/report-tree.js
+++ b/src/services/report-tree.js
@@ -1,0 +1,223 @@
+/**
+ * El informe con la forma que tiene la biblioteca: carpeta > carpeta > …
+ * > colección > materiales.
+ *
+ * La matriz plana (`activities` / `materials`) responde «¿qué ha visto este
+ * alumno?»; el árbol responde «¿por dónde va?», que es la pregunta que se hacía
+ * con el informe completo de Moodle cuando cada recurso era una actividad
+ * distinta y el orden del curso se leía de un vistazo.
+ *
+ * Es una función PURA: recibe lo que ya se consultó y no toca la base. Eso la
+ * hace probable sin Postgres, igual que `import-plan.js`.
+ *
+ * Dos reglas que gobiernan el módulo:
+ *
+ *   · **El árbol NO sustituye a nada.** `activities` y `materials` siguen
+ *     saliendo tal cual: son contrato ya emitido a la herramienta externa y a
+ *     la interfaz del profesor (Regla 0-bis). `tree` se añade al lado.
+ *   · **La carpeta es organización privada del profesor** (ADR-016). El informe
+ *     lo ve cualquier profesor del aula (ADR-023), y «Rehacer 2025» o
+ *     «Borradores baja de Ana» son información del claustro, no del curso: a un
+ *     compañero se le enseña la ruta sólo si la carpeta está compartida.
+ */
+
+const SIN_CARPETA = 'sin-carpeta'
+
+function textoOrden (valor) {
+  return String(valor ?? '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+}
+
+function comparaNodos (a, b) {
+  // Carpetas antes que material, como en un explorador de archivos.
+  if (a.type === 'folder' && b.type !== 'folder') return -1
+  if (b.type === 'folder' && a.type !== 'folder') return 1
+  return textoOrden(a.name ?? a.title).localeCompare(textoOrden(b.name ?? b.title), 'es')
+}
+
+/**
+ * Por dónde cuelga una actividad.
+ *
+ * Devuelve la lista de segmentos de carpeta, ya recortada por lo que el que
+ * mira tiene derecho a ver. Sin carpeta —o con la carpeta de otro profesor sin
+ * compartir— cuelga de un nodo sintético, nunca de la raíz a secas: así el
+ * árbol dice *por qué* no hay ruta en vez de fingir que no la hay.
+ */
+function rutaDeActividad (actividad, folderPaths, viewerSub) {
+  const carpeta = actividad.folderId ? folderPaths.get(actividad.folderId) : null
+  const propietario = {
+    sub: actividad.owner?.sub ?? carpeta?.ownerSub ?? null,
+    name: actividad.owner?.name ?? carpeta?.ownerName ?? null
+  }
+
+  if (!carpeta) {
+    return [{
+      key: `${SIN_CARPETA}:${propietario.sub ?? ''}`,
+      id: null,
+      name: 'Sin carpeta',
+      owner: propietario,
+      restricted: false
+    }]
+  }
+
+  const ajena = viewerSub && carpeta.ownerSub && carpeta.ownerSub !== viewerSub && !carpeta.shared
+  if (ajena) {
+    const nombre = carpeta.ownerName ? `Biblioteca de ${carpeta.ownerName}` : 'Biblioteca de otro profesor'
+    return [{
+      key: `propietario:${carpeta.ownerSub}`,
+      id: null,
+      name: nombre,
+      owner: { sub: carpeta.ownerSub, name: carpeta.ownerName },
+      restricted: true
+    }]
+  }
+
+  return carpeta.segments.map((segmento) => ({
+    key: `carpeta:${segmento.id}`,
+    id: segmento.id,
+    name: segmento.name,
+    owner: { sub: carpeta.ownerSub, name: carpeta.ownerName },
+    restricted: false
+  }))
+}
+
+function nodoMaterial (material, { historical, progreso }) {
+  const nodo = {
+    type: 'material',
+    key: `${material.kind}:${material.id}`,
+    kind: material.kind,
+    id: material.id,
+    title: material.title ?? null,
+    durationSeconds: material.durationSeconds ?? null,
+    pageCount: material.pageCount ?? null,
+    historical: Boolean(historical)
+  }
+  if (progreso) nodo.progress = progreso.get(material.id) ?? null
+  return nodo
+}
+
+/** Suma de un nodo contenedor: lo que se lee sin desplegarlo. */
+function resume (nodos) {
+  const total = { materials: 0, accessed: 0, sessions: 0, downloads: 0, lastAt: null, percent: null }
+  const porcentajes = []
+  for (const nodo of nodos) {
+    const parcial = nodo.summary ?? (nodo.type === 'material'
+      ? {
+          materials: 1,
+          accessed: nodo.progress && nodo.progress.sessions > 0 ? 1 : 0,
+          sessions: nodo.progress?.sessions ?? 0,
+          downloads: nodo.progress?.downloads ?? 0,
+          lastAt: nodo.progress?.lastAt ?? null,
+          percent: nodo.progress?.percent ?? null
+        }
+      : null)
+    if (!parcial) continue
+    total.materials += parcial.materials
+    total.accessed += parcial.accessed
+    total.sessions += parcial.sessions
+    total.downloads += parcial.downloads
+    if (parcial.lastAt && (!total.lastAt || new Date(parcial.lastAt) > new Date(total.lastAt))) {
+      total.lastAt = parcial.lastAt
+    }
+    // El porcentaje del contenedor pesa por material, no por rama: media de los
+    // materiales con dato. Un material sin telemetría no cuenta como 0 — decir
+    // «0 %» de algo que no se midió sería acusar a un alumno (ADR-030).
+    if (nodo.type === 'material') {
+      if (parcial.percent !== null) porcentajes.push(parcial.percent)
+    } else if (Array.isArray(nodo.percents)) {
+      porcentajes.push(...nodo.percents)
+    }
+  }
+  total.percent = porcentajes.length === 0
+    ? null
+    : Math.round(porcentajes.reduce((a, b) => a + b, 0) / porcentajes.length)
+  return { total, porcentajes }
+}
+
+function cierra (nodo) {
+  const { total, porcentajes } = resume(nodo.children ?? nodo.items ?? [])
+  nodo.summary = total
+  nodo.percents = porcentajes
+  return nodo
+}
+
+/**
+ * @param {object} entrada
+ * @param {Array} entrada.activities  actividades de `listCourseActivities`
+ * @param {Map}   entrada.folderPaths rutas de `listFolderPaths`
+ * @param {?string} entrada.viewerSub profesor que mira (null = operador: ve todo)
+ * @param {?Map}  entrada.progress    materialId → entrada del alumno; si viene,
+ *                                    cada hoja lleva su avance y cada nodo su suma
+ */
+export function buildReportTree ({ activities = [], folderPaths = new Map(), viewerSub = null, progress = null }) {
+  const raiz = { children: [], indice: new Map() }
+
+  const desciende = (nodo, segmento) => {
+    let hijo = nodo.indice.get(segmento.key)
+    if (!hijo) {
+      hijo = {
+        type: 'folder',
+        key: segmento.key,
+        id: segmento.id,
+        name: segmento.name,
+        owner: segmento.owner,
+        restricted: segmento.restricted,
+        children: [],
+        indice: new Map()
+      }
+      nodo.indice.set(segmento.key, hijo)
+      nodo.children.push(hijo)
+    }
+    return hijo
+  }
+
+  for (const actividad of activities) {
+    let destino = raiz
+    for (const segmento of rutaDeActividad(actividad, folderPaths, viewerSub)) {
+      destino = desciende(destino, segmento)
+    }
+
+    if (actividad.kind === 'collection') {
+      const coleccion = {
+        type: 'collection',
+        key: actividad.key,
+        id: actividad.id,
+        title: actividad.title ?? null,
+        owner: actividad.owner ?? null,
+        historical: Boolean(actividad.historical),
+        // El orden de la colección es el que compuso el profesor: se respeta.
+        items: (actividad.items ?? []).map((item) => nodoMaterial(item, {
+          historical: actividad.historical,
+          progreso: progress
+        }))
+      }
+      destino.children.push(cierra(coleccion))
+      continue
+    }
+
+    destino.children.push(nodoMaterial(actividad, {
+      historical: actividad.historical,
+      progreso: progress
+    }))
+  }
+
+  // De abajo arriba: ordenar y sumar. El `indice` y los `percents` son andamio
+  // del cálculo y no salen en el JSON.
+  const remata = (nodo) => {
+    for (const hijo of nodo.children) {
+      if (hijo.type === 'folder') remata(hijo)
+    }
+    nodo.children.sort(comparaNodos)
+    cierra(nodo)
+    delete nodo.indice
+  }
+  remata(raiz)
+
+  const limpia = (nodos) => nodos.map((nodo) => {
+    delete nodo.percents
+    if (nodo.children) limpia(nodo.children)
+    if (nodo.items) limpia(nodo.items)
+    return nodo
+  })
+
+  return limpia(raiz.children)
+}

--- a/src/ui/admin/platform-report.html
+++ b/src/ui/admin/platform-report.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Seguimiento de alumnos · MoodleShield</title>
+  <link rel="stylesheet" href="/assets/app.css?v={{ASSET_VERSION}}">
+</head>
+<body class="admin" data-page="platform-report">
+  <header class="bar admin-bar">
+    <div><p class="eyebrow" id="platformName">MoodleShield</p><h1 id="pageTitle">Seguimiento de alumnos</h1></div>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span>
+      <a class="btn" id="coursesLink" href="/admin/platforms">Aulas</a>
+      <a class="btn" id="contentLink" href="/admin/platforms">Contenido del aula</a>
+      <a class="btn" href="/admin/platforms">Volver al listado</a>
+      <form id="logout" method="post" action="/admin/logout"><input type="hidden" name="_csrf"><button>Salir</button></form>
+    </nav>
+  </header>
+
+  <main class="admin-main">
+    <p class="muted" id="issuer"></p>
+
+    <section class="panel">
+      <h2>Buscar un alumno</h2>
+      <p class="muted">Por su nombre de usuario de Moodle. Devuelve su avance en todas las aulas de esta instancia.</p>
+      <form id="searchForm" method="get">
+        <p>
+          <label for="identity">Nombre de usuario</label>
+          <input type="text" id="identity" name="identity" maxlength="255" autocomplete="off" placeholder="vsolano">
+          <button type="submit">Buscar</button>
+        </p>
+      </form>
+    </section>
+
+    <div id="telemetryNotice" class="notice" hidden></div>
+    <div id="empty" class="notice warning" hidden></div>
+    <div id="views"></div>
+  </main>
+
+  <script id="bootstrap" type="application/json">{{BOOTSTRAP}}</script>
+  <script type="module" src="/assets/admin-report.js?v={{ASSET_VERSION}}"></script>
+</body>
+</html>

--- a/src/ui/assets/admin-report.js
+++ b/src/ui/assets/admin-report.js
@@ -1,0 +1,278 @@
+import { etiquetaAlumno, identidadSecundaria, textoAvance } from './course-report.js?v=seguimiento-2'
+
+/**
+ * Seguimiento de alumnos en la consola de administración.
+ *
+ * Los datos vienen ya resueltos en el bootstrap —la consola no hace `fetch`—,
+ * así que aquí sólo hay pintado. Importa `textoAvance` y `etiquetaAlumno` del
+ * informe del profesor a propósito: las reglas de «sin datos, nunca cero» y
+ * «la celda del alumno jamás queda en blanco» tienen que ser las mismas en las
+ * dos pantallas, y duplicarlas es garantizar que se separen.
+ *
+ * Nada de `innerHTML`: aquí hay nombres de alumnos y títulos de material que
+ * escribe un profesor. Todo entra por `textContent`.
+ */
+
+const boot = JSON.parse(document.querySelector('#bootstrap')?.textContent || '{}')
+const el = (id) => document.getElementById(id)
+const RAYA = '—'
+
+const BASE = `/admin/platforms/${encodeURIComponent(boot.platform?.id ?? '')}/seguimiento`
+
+function nodo (tag, className, text) {
+  const node = document.createElement(tag)
+  if (className) node.className = className
+  if (text !== undefined && text !== null) node.textContent = String(text)
+  return node
+}
+
+function enlace (href, texto, className = 'btn') {
+  const a = nodo('a', className, texto)
+  a.href = href
+  return a
+}
+
+function fecha (valor) {
+  if (!valor) return RAYA
+  const date = new Date(valor)
+  if (Number.isNaN(date.getTime())) return RAYA
+  return date.toLocaleString('es-ES', {
+    day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit'
+  })
+}
+
+function tabla (columnas, filas, vacio) {
+  const seccion = document.createElement('div')
+  seccion.className = 'table-wrap'
+  if (filas.length === 0) {
+    seccion.append(nodo('p', 'muted', vacio))
+    return seccion
+  }
+  const table = document.createElement('table')
+  const thead = document.createElement('thead')
+  const cabecera = document.createElement('tr')
+  for (const columna of columnas) {
+    const th = nodo('th', null, columna)
+    th.scope = 'col'
+    cabecera.append(th)
+  }
+  thead.append(cabecera)
+  const tbody = document.createElement('tbody')
+  tbody.append(...filas)
+  table.append(thead, tbody)
+  seccion.append(table)
+  return seccion
+}
+
+function fila (celdas) {
+  const tr = document.createElement('tr')
+  for (const celda of celdas) {
+    tr.append(celda instanceof HTMLElement ? celda : nodo('td', null, celda))
+  }
+  return tr
+}
+
+function panel (titulo, ...hijos) {
+  const section = document.createElement('section')
+  section.className = 'panel'
+  if (titulo) section.append(nodo('h2', null, titulo))
+  section.append(...hijos)
+  return section
+}
+
+function tituloCurso (curso) {
+  if (!curso) return 'Aula sin nombre'
+  return curso.title
+    ? `${curso.title}${curso.label ? ` (${curso.label})` : ''}`
+    : `Aula ${curso.contextId}`
+}
+
+function urlCurso (contextId, sub = null) {
+  const params = new URLSearchParams({ contextId })
+  if (sub) params.set('alumno', sub)
+  return `${BASE}/curso?${params}`
+}
+
+/** El aviso que impide leer un hueco como un cero (ADR-030). */
+function avisoTelemetria (telemetry) {
+  const desde = telemetry?.videoStatsSince ?? telemetry?.opensSince
+  const aviso = el('telemetryNotice')
+  if (!aviso) return
+  aviso.textContent = desde
+    ? `El tiempo visto y las páginas leídas se registran desde el ${fecha(desde)}. ` +
+      'Lo anterior aparece como «sin datos»: las sesiones y las fechas sí están desde el primer día.'
+    : 'Todavía no hay telemetría de tiempo visto ni de páginas leídas.'
+  aviso.hidden = false
+}
+
+// ---------------------------------------------------------------- el árbol
+
+/**
+ * El material con la forma que le dio su profesor: carpeta > … > colección >
+ * materiales. Se pinta con `<details>` para que un aula grande no obligue a
+ * desplazarse por cien filas antes de llegar a lo que se busca.
+ */
+function pintaNodo (nodoInforme) {
+  if (nodoInforme.type === 'material') {
+    const linea = nodo('li', 'report-tree-item')
+    linea.append(nodo('span', 'report-tree-kind', nodoInforme.kind === 'video' ? 'vídeo' : 'PDF'))
+    linea.append(nodo('span', null, nodoInforme.title ?? nodoInforme.id))
+    if (nodoInforme.historical) {
+      linea.append(nodo('span', 'muted report-identity', 'retirado del aula'))
+    }
+    if (nodoInforme.progress !== undefined) {
+      linea.append(nodo('span', 'muted report-identity',
+        `${textoAvance(nodoInforme.progress, nodoInforme)} · ` +
+        `${nodoInforme.progress?.sessions ?? 0} sesión(es)`))
+    }
+    return linea
+  }
+
+  const contenedor = nodo('li', 'report-tree-branch')
+  const details = document.createElement('details')
+  details.open = true
+  const resumen = document.createElement('summary')
+  const esCarpeta = nodoInforme.type === 'folder'
+  resumen.append(nodo('span', 'report-tree-kind', esCarpeta ? 'carpeta' : 'colección'))
+  resumen.append(nodo('span', null, esCarpeta ? nodoInforme.name : (nodoInforme.title ?? nodoInforme.id)))
+  if (nodoInforme.restricted) {
+    resumen.append(nodo('span', 'muted report-identity', 'organización privada de su profesor'))
+  }
+  const suma = nodoInforme.summary
+  if (suma) {
+    const partes = [`${suma.accessed}/${suma.materials} abiertos`, `${suma.sessions} sesión(es)`]
+    if (suma.percent !== null) partes.push(`${suma.percent}% de media`)
+    resumen.append(nodo('span', 'muted report-identity', partes.join(' · ')))
+  }
+  details.append(resumen)
+  const lista = document.createElement('ul')
+  lista.className = 'report-tree'
+  lista.append(...(nodoInforme.children ?? nodoInforme.items ?? []).map(pintaNodo))
+  details.append(lista)
+  contenedor.append(details)
+  return contenedor
+}
+
+function pintaArbol (tree) {
+  const lista = document.createElement('ul')
+  lista.className = 'report-tree'
+  lista.append(...(tree ?? []).map(pintaNodo))
+  return lista
+}
+
+// --------------------------------------------------------------- las vistas
+
+function vistaCursos (data) {
+  const filas = (data.courses ?? []).map((curso) => {
+    const celda = document.createElement('td')
+    celda.append(enlace(urlCurso(curso.contextId), tituloCurso(curso), ''))
+    return fila([
+      celda,
+      String(curso.activities ?? 0),
+      fecha(curso.lastActivityAt),
+      fecha(curso.firstSeenAt)
+    ])
+  })
+  return panel('Aulas de esta instancia', tabla(
+    ['Aula', 'Actividades desplegadas', 'Última actividad', 'Primera vez vista'],
+    filas,
+    'Todavía no se ha abierto ninguna actividad de esta instancia.'
+  ))
+}
+
+function vistaCurso (data) {
+  const informe = data.report
+  avisoTelemetria(informe.telemetry)
+  el('pageTitle').textContent = tituloCurso(informe.course)
+
+  const filas = (informe.students ?? []).map((alumno) => {
+    const celdaAlumno = document.createElement('td')
+    const link = enlace(urlCurso(informe.course.contextId, alumno.sub), etiquetaAlumno(alumno), '')
+    link.title = alumno.sub ?? ''
+    celdaAlumno.append(link)
+    const secundaria = identidadSecundaria(alumno)
+    if (secundaria) celdaAlumno.append(nodo('span', 'muted report-identity', secundaria))
+    return fila([
+      celdaAlumno,
+      `${alumno.accessed}/${informe.totals.materials}`,
+      String(alumno.sessions),
+      String(alumno.opens ?? 0),
+      String(alumno.downloads),
+      fecha(alumno.lastAt)
+    ])
+  })
+
+  return [
+    panel('Alumnos', tabla(
+      ['Alumno', 'Materiales abiertos', 'Sesiones', 'Aperturas', 'Descargas', 'Última vez'],
+      filas,
+      'Todavía no hay ningún acceso registrado en esta aula.'
+    )),
+    panel('Material desplegado', pintaArbol(informe.tree))
+  ]
+}
+
+function vistaAlumno (informe, { conTitulo = true } = {}) {
+  const alumno = informe.student
+  const secundaria = identidadSecundaria(alumno)
+  const encabezado = nodo('p', 'muted',
+    `${tituloCurso(informe.course)} · ${informe.timeline.length} acceso(s) registrados`)
+
+  const bloque = panel(
+    conTitulo ? `${etiquetaAlumno(alumno)}${secundaria ? ` · ${secundaria}` : ''}` : tituloCurso(informe.course),
+    encabezado,
+    pintaArbol(informe.tree)
+  )
+
+  const accesos = informe.timeline.slice(0, 100).map((evento) => {
+    const material = informe.materials.find((m) => m.id === evento.materialId)
+    return fila([
+      fecha(evento.at),
+      evento.kind === 'video' ? 'vídeo' : 'PDF',
+      material?.title ?? evento.materialId,
+      { view: 'ver', read: 'leer', download: 'descargar', open: 'abrir actividad' }[evento.action] ?? evento.action
+    ])
+  })
+
+  return [bloque, panel('Últimos accesos', tabla(
+    ['Cuándo', 'Tipo', 'Material', 'Acción'],
+    accesos,
+    'Sin accesos registrados.'
+  ))]
+}
+
+function vistaBusqueda (data) {
+  const identidad = data.query?.identity ?? data.query?.sub ?? ''
+  el('pageTitle').textContent = `Seguimiento de ${identidad}`
+  if ((data.reports ?? []).length === 0) {
+    const vacio = el('empty')
+    vacio.textContent = `Ningún alumno de esta instancia con el usuario «${identidad}» ha abierto material todavía.`
+    vacio.hidden = false
+    return []
+  }
+  avisoTelemetria(data.reports[0].telemetry)
+  const alumno = data.reports[0].student
+  const secundaria = identidadSecundaria(alumno)
+  el('pageTitle').textContent = `${etiquetaAlumno(alumno)}${secundaria ? ` · ${secundaria}` : ''}`
+  return data.reports.flatMap((informe) => vistaAlumno(informe, { conTitulo: false }))
+}
+
+// ----------------------------------------------------------------- arranque
+
+const logoutCsrf = document.querySelector('#logout input[name="_csrf"]')
+if (logoutCsrf) logoutCsrf.value = boot.logoutCsrf ?? ''
+el('platformName').textContent = boot.platform?.name ?? 'MoodleShield'
+el('issuer').textContent = boot.platform?.issuer ?? ''
+el('coursesLink').href = BASE
+el('contentLink').href = `/admin/platforms/${encodeURIComponent(boot.platform?.id ?? '')}/contenido`
+el('searchForm').action = `${BASE}/alumno`
+if (boot.query?.identity) el('identity').value = boot.query.identity
+
+const vistas = {
+  courses: vistaCursos,
+  course: vistaCurso,
+  student: (data) => vistaAlumno(data.report),
+  search: vistaBusqueda
+}
+const salida = vistas[boot.view]?.(boot) ?? []
+el('views').append(...(Array.isArray(salida) ? salida : [salida]))

--- a/src/ui/assets/admin.js
+++ b/src/ui/assets/admin.js
@@ -47,7 +47,11 @@ function renderPlatforms () {
     importar.className = 'btn'
     importar.href = `/admin/platforms/${encodeURIComponent(platform.id)}/importar`
     importar.textContent = 'Importar'
-    action.append(link, ' ', content, ' ', importar)
+    const seguimiento = document.createElement('a')
+    seguimiento.className = 'btn'
+    seguimiento.href = `/admin/platforms/${encodeURIComponent(platform.id)}/seguimiento`
+    seguimiento.textContent = 'Seguimiento'
+    action.append(link, ' ', content, ' ', importar, ' ', seguimiento)
     tr.append(action)
     rows.append(tr)
   }

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -686,6 +686,54 @@ dialog label { display: block; font-size: .875rem; color: var(--muted); margin-b
 .report-sin-acceso td { color: var(--muted); }
 .report-detail { font-size: .8rem; padding: .2rem .5rem; }
 
+/* El árbol del informe: carpeta > … > colección > materiales. Se pinta con
+   <details>, así que un aula con cien materiales se puede plegar por ramas. */
+.report-tree { list-style: none; margin: 0; padding-left: 0; }
+.report-tree .report-tree { padding-left: 1.1rem; border-left: 1px solid var(--border); }
+.report-tree-item, .report-tree-branch { padding: .2rem 0; }
+.report-tree-item { display: flex; flex-wrap: wrap; gap: .4rem; align-items: baseline; }
+.report-tree summary { cursor: pointer; display: flex; flex-wrap: wrap; gap: .4rem; align-items: baseline; }
+.report-tree-kind {
+  font-size: .68rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0 .35rem;
+}
+.report-tree .report-identity { display: inline; }
+
+/* Lector del contrato de la API (/api/v1/docs). */
+.api-description p { max-width: 70ch; }
+.api-op { border-top: 1px solid var(--border); padding: .9rem 0; }
+.api-op:first-of-type { border-top: 0; }
+.api-op p { max-width: 70ch; }
+.api-op-head { display: flex; gap: .5rem; align-items: baseline; margin: 0 0 .3rem; }
+.api-method {
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .06em;
+  border-radius: var(--radius);
+  padding: .1rem .4rem;
+  border: 1px solid var(--border);
+}
+.api-method-get { color: var(--ok, inherit); }
+.api-method-post, .api-method-put, .api-method-delete { color: var(--warn, inherit); }
+.api-params p { display: flex; flex-wrap: wrap; gap: .4rem; align-items: baseline; }
+.api-params input { min-width: 16rem; }
+.api-output {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: .6rem .7rem;
+  max-height: 24rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: .82rem;
+}
+
 #collection-dialog { width: min(62rem, 96vw); }
 .collection-editor-grid {
   display: grid;

--- a/src/ui/assets/catalog.js
+++ b/src/ui/assets/catalog.js
@@ -18,7 +18,7 @@
  */
 
 import { createChunkedUploader } from './chunked-upload.js?v=import-1'
-import { createCourseReport } from './course-report.js?v=seguimiento-1'
+import { createCourseReport } from './course-report.js?v=seguimiento-2'
 
 const boot = JSON.parse(document.getElementById('bootstrap').textContent)
 

--- a/src/ui/assets/course-report.js
+++ b/src/ui/assets/course-report.js
@@ -71,6 +71,32 @@ export function textoAvance (entrada, material) {
   return `${visto} de ${duracion(total)}${entrada.percent === null ? '' : ` · ${entrada.percent}%`}`
 }
 
+/**
+ * Cómo se llama un alumno en el informe.
+ *
+ * Moodle omite los claims de nombre según su configuración de privacidad, y hay
+ * despliegues donde ni el nombre ni el username llegan. Se prueba por
+ * truthiness y no con `??`, porque lo que llegaba era una cadena vacía —un
+ * valor— y `??` la daba por buena: la celda quedaba en blanco. Un alumno del
+ * que sólo se conoce el `sub` sale con su `sub` abreviado, nunca con un hueco.
+ */
+export function etiquetaAlumno (alumno) {
+  for (const valor of [alumno?.name, alumno?.identity]) {
+    const texto = String(valor ?? '').trim()
+    if (texto) return texto
+  }
+  const sub = String(alumno?.sub ?? '').trim()
+  if (!sub) return 'Alumno sin identificar'
+  return sub.length > 16 ? `${sub.slice(0, 15)}…` : sub
+}
+
+/** El username debajo del nombre, sólo si aporta algo distinto. */
+export function identidadSecundaria (alumno) {
+  const identidad = String(alumno?.identity ?? '').trim()
+  if (!identidad) return null
+  return identidad === etiquetaAlumno(alumno) ? null : identidad
+}
+
 /** Alumnos que no han tocado nada aparecen igual: no verlos también es dato. */
 function resumenAlumno (alumno, materiales) {
   const conAcceso = alumno.materials.filter((entrada) => entrada.sessions > 0).length
@@ -165,9 +191,12 @@ export function createCourseReport ({ sessionToken }) {
       const fila = document.createElement('tr')
 
       const alumnoCelda = document.createElement('td')
-      alumnoCelda.append(nodo('strong', null, alumno.name ?? alumno.identity ?? alumno.sub))
-      if (alumno.identity && alumno.name) {
-        alumnoCelda.append(nodo('span', 'muted report-identity', alumno.identity))
+      const principal = nodo('strong', null, etiquetaAlumno(alumno))
+      principal.title = alumno.sub ?? ''
+      alumnoCelda.append(principal)
+      const secundaria = identidadSecundaria(alumno)
+      if (secundaria) {
+        alumnoCelda.append(nodo('span', 'muted report-identity', secundaria))
       }
 
       const boton = nodo('button', 'report-detail', 'Detalle')
@@ -238,8 +267,9 @@ export function createCourseReport ({ sessionToken }) {
     }
 
     cuerpoEl.replaceChildren(...filas)
-    tituloEl.textContent = `${alumno.name ?? alumno.identity ?? alumno.sub}` +
-      `${alumno.identity && alumno.name ? ` · ${alumno.identity}` : ''}` +
+    const secundaria = identidadSecundaria(alumno)
+    tituloEl.textContent = etiquetaAlumno(alumno) +
+      (secundaria ? ` · ${secundaria}` : '') +
       ` · ${detalle.course.title ?? detalle.course.contextId}`
   }
 

--- a/src/ui/assets/openapi.js
+++ b/src/ui/assets/openapi.js
@@ -1,0 +1,242 @@
+/**
+ * Lector y probador del contrato de `/api/v1`.
+ *
+ * No es Swagger UI a propósito. `swagger-ui-dist` son ~12 MB desempaquetados y
+ * sería la primera dependencia de producción que existe sólo para documentar;
+ * además habría que verificar que su bundle no pide `'unsafe-eval'`, porque la
+ * CSP de esta aplicación es `script-src 'self'` sin excepciones (T32) y abrirla
+ * por una página de documentación no compensa.
+ *
+ * El «Probar» se limita a la **API de informes**, que es de sólo lectura. La de
+ * contenido escribe eligiendo `owner_sub`: su token suplanta a cualquier
+ * profesor, y ofrecer un formulario que invita a pegarlo en un navegador —donde
+ * acaba en el historial de un portátil compartido— sería regalarlo. Para eso
+ * están `scripts/upload-content.sh` y los `curl` que esta misma página genera.
+ *
+ * Nada de `innerHTML`: el spec es nuestro, pero las respuestas que se pintan
+ * llevan nombres de alumnos y títulos que escribe un profesor.
+ */
+
+const el = (id) => document.getElementById(id)
+const REPORTS_PREFIX = '/api/v1/reports'
+
+// El token vive aquí y en ningún otro sitio: ni localStorage ni sessionStorage.
+const credenciales = () => ({
+  token: el('token').value.trim(),
+  platformId: el('platformId').value.trim()
+})
+
+function nodo (tag, className, text) {
+  const node = document.createElement(tag)
+  if (className) node.className = className
+  if (text !== undefined && text !== null) node.textContent = String(text)
+  return node
+}
+
+/**
+ * Markdown mínimo: sólo párrafos, negrita y `código`. El spec lo escribimos
+ * nosotros, pero pintarlo con `innerHTML` dejaría abierta la puerta el día que
+ * una descripción venga de otro sitio.
+ */
+function enLinea (destino, texto) {
+  for (const parte of String(texto).split(/(\*\*[^*]+\*\*|`[^`]+`)/g)) {
+    if (!parte) continue
+    if (parte.startsWith('**') && parte.endsWith('**')) destino.append(nodo('strong', null, parte.slice(2, -2)))
+    else if (parte.startsWith('`') && parte.endsWith('`')) destino.append(nodo('code', null, parte.slice(1, -1)))
+    else destino.append(document.createTextNode(parte))
+  }
+  return destino
+}
+
+function parrafos (texto) {
+  const bloque = document.createDocumentFragment()
+  for (const trozo of String(texto ?? '').split(/\n{2,}/)) {
+    if (!trozo.trim()) continue
+    const lineas = trozo.split('\n').filter((linea) => linea.trim())
+    if (lineas.every((linea) => linea.trimStart().startsWith('- '))) {
+      const lista = document.createElement('ul')
+      for (const linea of lineas) {
+        lista.append(enLinea(document.createElement('li'), linea.trimStart().slice(2)))
+      }
+      bloque.append(lista)
+      continue
+    }
+    bloque.append(enLinea(document.createElement('p'), lineas.join(' ')))
+  }
+  return bloque
+}
+
+function esInforme (ruta) {
+  return ruta.startsWith(REPORTS_PREFIX)
+}
+
+/**
+ * Resuelve un `$ref` local del propio documento.
+ *
+ * Sin esto, un parámetro declarado como `$ref` llega sin `name` y la página
+ * pintaba un campo «undefined». Sólo se siguen referencias internas
+ * (`#/…`): una externa sería una petición a otro origen.
+ */
+function resuelve (spec, valor) {
+  if (!valor?.$ref || !valor.$ref.startsWith('#/')) return valor
+  let actual = spec
+  for (const tramo of valor.$ref.slice(2).split('/')) {
+    actual = actual?.[tramo.replace(/~1/g, '/').replace(/~0/g, '~')]
+  }
+  return actual ?? valor
+}
+
+/** El `curl` equivalente: lo que de verdad se acaba pegando en una terminal. */
+function comandoCurl (ruta, metodo, valores, { platformId }, origen) {
+  let camino = ruta
+  const query = new URLSearchParams()
+  if (esInforme(ruta)) query.set('platformId', platformId || '$PLATFORM_ID')
+  for (const [nombre, { valor, in: sitio }] of Object.entries(valores)) {
+    if (!valor) continue
+    if (sitio === 'path') camino = camino.replace(`{${nombre}}`, encodeURIComponent(valor))
+    else query.set(nombre, valor)
+  }
+  const cadena = query.toString()
+  const url = `${origen}${camino}${cadena ? `?${cadena}` : ''}`
+  // El token nunca se escribe en el comando: se deja el nombre de la variable
+  // de entorno, que es como se usa y como no acaba en el historial de la shell.
+  const autorizacion = esInforme(ruta) ? '$REPORTS_API_TOKEN' : '$CONTENT_API_TOKEN'
+  const lineas = [`curl -sS ${metodo === 'get' ? '' : `-X ${metodo.toUpperCase()} `}"${url}" \\`,
+    `  -H "Authorization: Bearer ${autorizacion}"`]
+  if (!esInforme(ruta) && ruta !== '/api/v1/platforms') {
+    lineas.push('  -H "X-MoodleShield-Platform-Id: $PLATFORM_ID" \\')
+    lineas.push('  -H "X-MoodleShield-Owner-Sub: $OWNER_SUB"')
+  }
+  return `${lineas.join('\n')} | jq`
+}
+
+function pintaOperacion (spec, ruta, metodo, operacion, origen) {
+  const bloque = nodo('article', 'api-op')
+  const cabecera = nodo('h3', 'api-op-head')
+  cabecera.append(nodo('span', `api-method api-method-${metodo}`, metodo.toUpperCase()))
+  cabecera.append(nodo('code', null, ruta))
+  bloque.append(cabecera)
+  bloque.append(nodo('p', null, operacion.summary ?? ''))
+  if (operacion.description) bloque.append(parrafos(operacion.description))
+
+  // `platformId` se pide una vez arriba, no en cada operación.
+  const parametros = (operacion.parameters ?? [])
+    .map((parametro) => resuelve(spec, parametro))
+    .filter((parametro) => parametro?.name && parametro.name !== 'platformId')
+  const valores = {}
+  const probable = metodo === 'get' && esInforme(ruta)
+
+  if (parametros.length > 0) {
+    const lista = nodo('div', 'api-params')
+    for (const parametro of parametros) {
+      const campo = document.createElement('p')
+      const etiqueta = nodo('label', null, `${parametro.name}${parametro.required ? ' *' : ''}`)
+      const input = document.createElement('input')
+      input.type = 'text'
+      input.autocomplete = 'off'
+      input.placeholder = parametro.example ?? parametro.schema?.format ?? parametro.in
+      input.disabled = !probable
+      etiqueta.htmlFor = input.id = `p-${metodo}-${ruta}-${parametro.name}`.replace(/[^\w-]/g, '_')
+      valores[parametro.name] = { valor: '', in: parametro.in }
+      input.addEventListener('input', () => { valores[parametro.name].valor = input.value.trim() })
+      campo.append(etiqueta, input)
+      if (parametro.description) campo.append(nodo('span', 'muted report-identity', parametro.description))
+      lista.append(campo)
+    }
+    bloque.append(lista)
+  }
+
+  const salida = nodo('pre', 'api-output')
+  salida.hidden = true
+  const acciones = document.createElement('p')
+
+  const verCurl = nodo('button', null, 'Ver curl')
+  verCurl.type = 'button'
+  verCurl.addEventListener('click', () => {
+    salida.hidden = false
+    salida.textContent = comandoCurl(ruta, metodo, valores, credenciales(), origen)
+  })
+  acciones.append(verCurl)
+
+  if (probable) {
+    const probar = nodo('button', 'primary', 'Probar')
+    probar.type = 'button'
+    probar.addEventListener('click', async () => {
+      const { token, platformId } = credenciales()
+      salida.hidden = false
+      if (!token || !platformId) {
+        salida.textContent = 'Rellena arriba el token de informes y el platformId.'
+        return
+      }
+      let camino = ruta
+      const query = new URLSearchParams({ platformId })
+      for (const [nombre, { valor, in: sitio }] of Object.entries(valores)) {
+        if (!valor) continue
+        if (sitio === 'path') camino = camino.replace(`{${nombre}}`, encodeURIComponent(valor))
+        else query.set(nombre, valor)
+      }
+      if (camino.includes('{')) {
+        salida.textContent = 'Falta algún parámetro de la ruta.'
+        return
+      }
+      salida.textContent = 'Pidiendo…'
+      try {
+        const res = await fetch(`${camino}?${query}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        })
+        const cuerpo = await res.text()
+        let bonito = cuerpo
+        try { bonito = JSON.stringify(JSON.parse(cuerpo), null, 2) } catch { /* no era JSON */ }
+        salida.textContent = `HTTP ${res.status}\n\n${bonito}`
+      } catch (err) {
+        salida.textContent = `No se pudo completar la petición: ${err.message}`
+      }
+    })
+    acciones.append(' ', probar)
+  } else if (metodo === 'get') {
+    acciones.append(' ', nodo('span', 'muted', 'Sólo se puede probar la API de informes desde aquí.'))
+  } else {
+    acciones.append(' ', nodo('span', 'muted', 'Operación de escritura: pruébala con curl o con el script.'))
+  }
+
+  bloque.append(acciones, salida)
+  return bloque
+}
+
+async function arranca () {
+  let spec
+  try {
+    const res = await fetch('/api/v1/openapi.json')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    spec = await res.json()
+  } catch (err) {
+    const aviso = el('specError')
+    aviso.textContent = 'No hay ninguna API de integración activa en este despliegue, o no se pudo ' +
+      `leer su contrato (${err.message}). Se activan poniendo REPORTS_API_TOKEN o CONTENT_API_TOKEN.`
+    aviso.hidden = false
+    return
+  }
+
+  el('specTitle').textContent = spec.info?.title ?? 'API de integración'
+  el('specSummary').textContent = `${spec.info?.summary ?? ''} · versión ${spec.info?.version ?? '?'}`
+  const descripcion = el('specDescription')
+  descripcion.append(parrafos(spec.info?.description))
+  descripcion.hidden = false
+
+  const origen = spec.servers?.[0]?.url ?? location.origin
+  const contenedor = el('operations')
+  for (const tag of spec.tags ?? []) {
+    const seccion = nodo('section', 'panel')
+    seccion.append(nodo('h2', null, tag.name))
+    if (tag.description) seccion.append(nodo('p', 'muted', tag.description))
+    for (const [ruta, item] of Object.entries(spec.paths ?? {})) {
+      for (const [metodo, operacion] of Object.entries(item)) {
+        if (!(operacion.tags ?? []).includes(tag.name)) continue
+        seccion.append(pintaOperacion(spec, ruta, metodo, operacion, origen))
+      }
+    }
+    contenedor.append(seccion)
+  }
+}
+
+void arranca()

--- a/src/ui/openapi.html
+++ b/src/ui/openapi.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>API de integración · MoodleShield</title>
+  <link rel="stylesheet" href="/assets/app.css?v={{ASSET_VERSION}}">
+</head>
+<body class="admin" data-page="openapi">
+  <header class="bar admin-bar">
+    <div><p class="eyebrow">MoodleShield</p><h1 id="specTitle">API de integración</h1></div>
+    <nav><span class="build" title="Entorno y compilación que sirven esta página"><b class="build-env">{{APP_ENV}}</b> {{APP_VERSION}}</span>
+      <a class="btn" id="downloadSpec" href="/api/v1/openapi.json">openapi.json</a>
+    </nav>
+  </header>
+
+  <main class="admin-main">
+    <p class="muted" id="specSummary"></p>
+    <div id="specError" class="notice warning" hidden></div>
+    <div id="specDescription" class="panel api-description" hidden></div>
+
+    <section class="panel">
+      <h2>Probar</h2>
+      <p class="muted">
+        El token se queda en esta pestaña: no se guarda en el navegador ni sale de este origen.
+        Sólo se puede probar la <strong>API de informes</strong>, que es de sólo lectura; la de
+        contenido escribe suplantando a un profesor y su token no debe pasearse por un navegador.
+      </p>
+      <p>
+        <label for="token">Token de informes</label>
+        <input type="password" id="token" autocomplete="off" spellcheck="false" placeholder="REPORTS_API_TOKEN">
+      </p>
+      <p>
+        <label for="platformId">platformId</label>
+        <input type="text" id="platformId" autocomplete="off" spellcheck="false"
+               placeholder="00000000-0000-4000-8000-000000000000">
+      </p>
+    </section>
+
+    <div id="operations"></div>
+  </main>
+
+  <script type="module" src="/assets/openapi.js?v={{ASSET_VERSION}}"></script>
+</body>
+</html>

--- a/test/claims.test.js
+++ b/test/claims.test.js
@@ -72,6 +72,39 @@ test('toLaunchContext aplana el id_token a la forma que usa la app', () => {
   assert.equal(ctx.returnUrl, 'https://moodle.example.org/vuelta')
 })
 
+test('si Moodle no comparte el nombre, el nombre es null y no cadena vacía', () => {
+  // Moodle omite `name`/`given_name`/`family_name` según su configuración de
+  // privacidad. Devolver '' hacía que ese vacío atravesara la sesión y acabara
+  // guardado en los eventos, y el informe de seguimiento enseñaba la celda
+  // «Alumno» en blanco porque `'' ?? identity ?? sub` es ''.
+  const ctx = toLaunchContext(
+    { iss: PLATFORM.issuer, aud: 'CID', sub: 'moodle-user-42', [CLAIM.roles]: [LEARNER] },
+    PLATFORM
+  )
+  assert.equal(ctx.name, null)
+
+  // Un nombre en blancos tampoco es un nombre.
+  assert.equal(
+    toLaunchContext({ iss: PLATFORM.issuer, aud: 'CID', sub: 'u', name: '   ' }, PLATFORM).name,
+    null
+  )
+})
+
+test('sin claim name se compone del nombre y los apellidos', () => {
+  const ctx = toLaunchContext(
+    {
+      iss: PLATFORM.issuer,
+      aud: 'CID',
+      sub: 'u',
+      given_name: 'Vega',
+      family_name: 'Solano',
+      [CLAIM.roles]: [LEARNER]
+    },
+    PLATFORM
+  )
+  assert.equal(ctx.name, 'Vega Solano')
+})
+
 test('con varios aud se toma el primero como client_id', () => {
   const ctx = toLaunchContext(
     { iss: PLATFORM.issuer, aud: ['CID', 'otro'], sub: 'u', [CLAIM.roles]: [] },

--- a/test/course-report.test.js
+++ b/test/course-report.test.js
@@ -9,7 +9,7 @@ import {
   getStudentCourseReport,
   listKnownCourses
 } from '../src/services/course-report.js'
-import { textoAvance } from '../src/ui/assets/course-report.js'
+import { etiquetaAlumno, identidadSecundaria, textoAvance } from '../src/ui/assets/course-report.js'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -38,8 +38,10 @@ test('el informe no selecciona jamás ip ni user_agent', async () => {
   // externa o en la pantalla de un profesor.
   for (const file of [
     'src/services/course-report.js',
+    'src/services/report-tree.js',
     'src/routes/reports.js',
-    'src/routes/reports-api.js'
+    'src/routes/reports-api.js',
+    'src/admin/reports.js'
   ]) {
     const code = soloCodigo(await readFile(path.join(root, file), 'utf8'))
     assert.doesNotMatch(code, /user_agent/, `${file} selecciona user_agent`)
@@ -69,6 +71,61 @@ test('la lista de espectadores la abre ver el material, no ser su autor', async 
     assert.match(cuerpo, /contextId: req\.session\.contextId/)
     assert.doesNotMatch(cuerpo, /ForOwner/, `${file}: /viewers ya no filtra por propietario`)
   }
+})
+
+test('el seguimiento de la consola es sólo lectura y va detrás de requireAdmin', async () => {
+  const rutas = soloCodigo(await readFile(path.join(root, 'src/admin/routes.js'), 'utf8'))
+  const montaje = rutas.indexOf("adminRouter.use('/platforms/:id/seguimiento'")
+  assert.ok(montaje > 0, 'el seguimiento tiene que montarse en la consola')
+  assert.ok(
+    montaje > rutas.indexOf('adminRouter.use(requireAdmin)'),
+    'montarlo antes de requireAdmin lo dejaría abierto sin cookie de administrador'
+  )
+
+  const consola = soloCodigo(await readFile(path.join(root, 'src/admin/reports.js'), 'utf8'))
+  assert.doesNotMatch(consola, /adminReportsRouter\.(post|put|patch|delete)/,
+    'la consola de seguimiento no escribe nada')
+  // El token de la API de informes es un secreto de servidor: aquí manda la
+  // cookie de administrador, y ese token no debe aparecer ni de lejos.
+  assert.doesNotMatch(consola, /REPORTS_API_TOKEN|reportsApi/)
+
+  // La página no hace fetch: los datos van en el bootstrap, como el resto de la
+  // consola, así que no hay una API nueva que proteger.
+  const vista = soloCodigo(await readFile(path.join(root, 'src/ui/assets/admin-report.js'), 'utf8'))
+  assert.doesNotMatch(vista, /fetch\(/)
+  assert.doesNotMatch(vista, /innerHTML/)
+})
+
+test('el operador ve las rutas de carpeta; un profesor del aula, no', () => {
+  // ADR-016 frente a ADR-023: el material del aula lo ve cualquier profesor,
+  // pero cómo lo tiene organizado su dueño en su biblioteca es cosa suya.
+  assert.match(
+    String(buildCourseReport),
+    /viewerSub/,
+    'el informe tiene que saber quién mira'
+  )
+})
+
+test('la celda del alumno nunca queda en blanco, ni con nombre vacío', () => {
+  // El fallo real: Moodle no comparte el nombre, `toLaunchContext` devolvía ''
+  // en vez de null y `name ?? identity ?? sub` daba por bueno el vacío. La
+  // columna «Alumno» aparecía en blanco mientras el resto de la fila se pintaba.
+  assert.equal(etiquetaAlumno({ name: 'Vega Solano', identity: 'vsolano', sub: 's-1' }), 'Vega Solano')
+  assert.equal(etiquetaAlumno({ name: '', identity: 'vsolano', sub: 's-1' }), 'vsolano')
+  assert.equal(etiquetaAlumno({ name: '   ', identity: '', sub: 'moodle-user-42' }), 'moodle-user-42')
+  assert.equal(etiquetaAlumno({ name: null, identity: null, sub: null }), 'Alumno sin identificar')
+  // Un `sub` largo se abrevia para no reventar la columna; el completo va en title.
+  assert.equal(
+    etiquetaAlumno({ sub: '2b9f4a1c-7d3e-4f8a-9c1b-556677889900' }),
+    '2b9f4a1c-7d3e-4…'
+  )
+})
+
+test('el username sólo se repite debajo del nombre si aporta algo', () => {
+  assert.equal(identidadSecundaria({ name: 'Vega Solano', identity: 'vsolano' }), 'vsolano')
+  // Si el username ES la etiqueta principal, repetirlo debajo es ruido.
+  assert.equal(identidadSecundaria({ name: '', identity: 'vsolano', sub: 's-1' }), null)
+  assert.equal(identidadSecundaria({ name: 'Vega Solano', identity: '' }), null)
 })
 
 test('un material sin telemetría dice «sin datos», nunca cero', () => {

--- a/test/integration/course-report.integration.js
+++ b/test/integration/course-report.integration.js
@@ -6,6 +6,7 @@ import { runMigrations } from '../../src/db/migrate.js'
 import { createVideoAndJob, recordView } from '../../src/services/videos.js'
 import { createDocumentAndJob, recordDocumentView } from '../../src/services/documents.js'
 import { createCollection } from '../../src/services/collections.js'
+import { createFolder } from '../../src/services/folders.js'
 import { createResourcePlacements } from '../../src/services/resource-placements.js'
 import { rememberContext } from '../../src/services/lti-contexts.js'
 import { saveVideoBeat, normalizeVideoBeat } from '../../src/services/viewing-stats.js'
@@ -37,6 +38,7 @@ let HISTORICO
 let HISTORICO_REVISION
 let COLECCION
 let ITEM_VIDEO
+let CARPETA_TEMA2
 
 async function nuevoVideo (title, { duracion = null } = {}) {
   const id = randomUUID()
@@ -137,11 +139,21 @@ test.before(async () => {
   ITEM_VIDEO = itemVideo
   const otroCurso = await nuevoVideo('Óptica', { duracion: 100 })
 
+  // Álgebra > Tema 2: dos niveles, para que el árbol del informe tenga algo
+  // que reproducir. La carpeta es organización privada de Ana (ADR-016).
+  const algebra = await createFolder({
+    platformId: PLATFORM, ownerSub: ANA, ownerName: 'Ana', name: 'Álgebra'
+  })
+  CARPETA_TEMA2 = await createFolder({
+    platformId: PLATFORM, ownerSub: ANA, ownerName: 'Ana', name: 'Tema 2', parentId: algebra.id
+  })
+
   COLECCION = await createCollection({
     platformId: PLATFORM,
     ownerSub: ANA,
     ownerName: 'Ana',
     title: 'Tema 1',
+    folderId: CARPETA_TEMA2.id,
     items: [{ kind: 'video', id: itemVideo.id }]
   })
 
@@ -282,6 +294,86 @@ test('#76: un alumno de otro curso no existe para este informe', async () => {
     await getStudentCourseReport({ platformId: PLATFORM, contextId: CURSO, sub: 'nadie' }),
     null
   )
+})
+
+test('el informe devuelve el nombre y el username del alumno, no un hueco', async () => {
+  // El bug: Moodle omite el claim de nombre según su privacidad, llegaba '' y
+  // ese vacío se guardaba en los eventos y atravesaba `name ?? identity ?? sub`
+  // hasta dejar la celda «Alumno» en blanco.
+  const informe = await buildCourseReport({ platformId: PLATFORM, contextId: CURSO })
+  const alumno = informe.students.find((student) => student.sub === ALUMNO)
+  assert.equal(alumno.name, 'Vega Solano')
+  assert.equal(alumno.identity, 'vsolano')
+
+  // Y una fila escrita con nombre vacío —las que ya están en test y producción,
+  // que no se tocan— se lee como ausencia, no como un nombre en blanco.
+  const anonimo = 'alumno-sin-nombre'
+  await query(
+    `INSERT INTO activity_open_event
+       (platform_id, context_id, resource_link_id, resource_kind, resource_id,
+        user_sub, user_name, user_identity, session_jti)
+     VALUES ($1,$2,'rl-1','video',$3,$4,'','',$5)`,
+    [PLATFORM, CURSO, VIDEO.id, anonimo, randomUUID()]
+  )
+  const conVacios = await buildCourseReport({ platformId: PLATFORM, contextId: CURSO })
+  const sinNombre = conVacios.students.find((student) => student.sub === anonimo)
+  assert.equal(sinNombre.name, null)
+  assert.equal(sinNombre.identity, null)
+})
+
+test('el árbol del informe reproduce la biblioteca: Álgebra > Tema 2 > colección', async () => {
+  const informe = await buildCourseReport({ platformId: PLATFORM, contextId: CURSO })
+
+  const algebra = informe.tree.find((nodo) => nodo.name === 'Álgebra')
+  assert.ok(algebra, 'la carpeta raíz del material tiene que salir en el árbol')
+  const tema2 = algebra.children.find((nodo) => nodo.name === 'Tema 2')
+  assert.ok(tema2, 'la carpeta anidada también')
+
+  const coleccion = tema2.children.find((nodo) => nodo.type === 'collection')
+  assert.equal(coleccion.id, COLECCION.id)
+  assert.deepEqual(coleccion.items.map((item) => item.id), [ITEM_VIDEO.id])
+
+  // Lo que no está en carpeta cuelga de «Sin carpeta», y el histórico va marcado.
+  const sueltos = informe.tree.find((nodo) => nodo.name === 'Sin carpeta')
+  assert.ok(sueltos.children.some((nodo) => nodo.id === VIDEO.id))
+  assert.ok(sueltos.children.some((nodo) => nodo.id === HISTORICO.id && nodo.historical))
+})
+
+test('el árbol de un alumno lleva su avance en cada hoja y la suma en cada carpeta', async () => {
+  const detalle = await getStudentCourseReport({
+    platformId: PLATFORM, contextId: CURSO, sub: ALUMNO
+  })
+
+  const sueltos = detalle.tree.find((nodo) => nodo.name === 'Sin carpeta')
+  const video = sueltos.children.find((nodo) => nodo.id === VIDEO.id)
+  assert.equal(video.progress.sessions, 2)
+  assert.equal(video.progress.percent, 50)
+
+  const pdf = sueltos.children.find((nodo) => nodo.id === PDF.id)
+  assert.equal(pdf.progress.downloads, 1)
+
+  // La carpeta suma lo que cuelga de ella, sin que el consumidor cruce por id.
+  assert.ok(sueltos.summary.sessions >= 3)
+  assert.equal(sueltos.summary.materials, sueltos.children.length)
+})
+
+test('el árbol no le enseña a un profesor las carpetas privadas de otro', async () => {
+  // ADR-016: el árbol es organización privada. El material del aula sí sale
+  // —es del curso—, pero sin el nombre de la carpeta de su dueño.
+  const otroProfesor = await buildCourseReport({
+    platformId: PLATFORM, contextId: CURSO, viewerSub: 'teacher-luis'
+  })
+  const json = JSON.stringify(otroProfesor.tree)
+  assert.doesNotMatch(json, /Álgebra/)
+  assert.match(json, /Biblioteca de Ana/)
+  // El material sigue estando: no se oculta contenido, sólo su organización.
+  assert.match(json, new RegExp(COLECCION.id))
+
+  // Su dueña sí ve su propia ruta.
+  const comoAna = await buildCourseReport({
+    platformId: PLATFORM, contextId: CURSO, viewerSub: ANA
+  })
+  assert.match(JSON.stringify(comoAna.tree), /Álgebra/)
 })
 
 test('#76: la fila de acceso sigue siendo la del registro forense', async () => {

--- a/test/openapi.test.js
+++ b/test/openapi.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { contentApiRouter } from '../src/routes/content-api.js'
+import { reportsApiRouter } from '../src/routes/reports-api.js'
+import { createUploadsRouter } from '../src/routes/uploads.js'
+import { createImportsRouter } from '../src/routes/imports.js'
+import { specParaDespliegue } from '../src/routes/openapi.js'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * El contrato se escribe a mano; lo que impide que envejezca es esta prueba.
+ *
+ * Un spec desincronizado es peor que no tenerlo: quien integra confía en él y
+ * pierde la tarde. Aquí se compara con las rutas que los routers registran de
+ * verdad, no con una lista escrita al lado.
+ */
+
+const spec = JSON.parse(await readFile(path.join(root, 'src/api/openapi.json'), 'utf8'))
+
+/** Rutas reales de un router, con el prefijo con el que se monta en app.js. */
+function rutasDe (router, prefijo) {
+  const rutas = []
+  for (const capa of router.stack) {
+    if (!capa.route) continue
+    const camino = capa.route.path === '/' ? '' : capa.route.path
+    for (const metodo of Object.keys(capa.route.methods ?? {})) {
+      // Express normaliza `:param`; OpenAPI usa `{param}`.
+      rutas.push(`${metodo} ${prefijo}${camino}`.replace(/:([A-Za-z0-9_]+)/g, '{$1}'))
+    }
+  }
+  return rutas
+}
+
+const REALES = [
+  ...rutasDe(reportsApiRouter, '/api/v1/reports'),
+  ...rutasDe(contentApiRouter, '/api/v1'),
+  ...rutasDe(createUploadsRouter(), '/api/v1/uploads'),
+  ...rutasDe(createImportsRouter(), '/api/v1/imports')
+].sort()
+
+const DOCUMENTADAS = Object.entries(spec.paths)
+  .flatMap(([ruta, item]) => Object.keys(item).map((metodo) => `${metodo} ${ruta}`))
+  .sort()
+
+test('el openapi.json documenta exactamente las rutas que existen', () => {
+  const faltan = REALES.filter((ruta) => !DOCUMENTADAS.includes(ruta))
+  const sobran = DOCUMENTADAS.filter((ruta) => !REALES.includes(ruta))
+  assert.deepEqual(faltan, [], 'hay rutas de /api/v1 sin documentar en src/api/openapi.json')
+  assert.deepEqual(sobran, [], 'el spec promete rutas que no existen')
+})
+
+test('un sub-router nuevo bajo /api/v1 obliga a tocar esta prueba', () => {
+  // Express 5 no expone el prefijo con el que se monta un router anidado, así
+  // que arriba se enumeran a mano. Contarlos evita que uno nuevo pase de largo
+  // y quede fuera del contrato sin que nadie se entere.
+  const anidados = contentApiRouter.stack.filter((capa) => !capa.route && capa.handle?.stack)
+  assert.equal(anidados.length, 2, 'sub-routers montados en contentApiRouter: /uploads y /imports')
+})
+
+test('los dos tokens son esquemas distintos y no se confunden', () => {
+  const esquemas = spec.components.securitySchemes
+  assert.ok(esquemas.reportsApiToken && esquemas.contentApiToken)
+  for (const ruta of Object.keys(spec.paths)) {
+    for (const operacion of Object.values(spec.paths[ruta])) {
+      const claves = operacion.security.flatMap((s) => Object.keys(s))
+      const esperado = ruta.startsWith('/api/v1/reports') ? 'reportsApiToken' : 'contentApiToken'
+      assert.ok(claves.includes(esperado), `${ruta} declara el token equivocado`)
+      assert.ok(
+        !claves.includes(esperado === 'reportsApiToken' ? 'contentApiToken' : 'reportsApiToken'),
+        `${ruta} mezcla los dos tokens`
+      )
+    }
+  }
+})
+
+test('el spec se recorta a las APIs que este despliegue tiene activas', () => {
+  // Prometer una operación que responde 404 porque su token no está puesto es
+  // peor que no documentarla.
+  const soloInformes = specParaDespliegue(spec, { reports: true, content: false })
+  assert.ok(Object.keys(soloInformes.paths).every((ruta) => ruta.startsWith('/api/v1/reports')))
+  assert.deepEqual(soloInformes.tags.map((t) => t.name), ['Informes'])
+
+  const soloContenido = specParaDespliegue(spec, { reports: false, content: true })
+  assert.ok(Object.keys(soloContenido.paths).every((ruta) => !ruta.startsWith('/api/v1/reports')))
+  assert.deepEqual(soloContenido.tags.map((t) => t.name), ['Contenido'])
+
+  const ninguna = specParaDespliegue(spec, { reports: false, content: false })
+  assert.deepEqual(Object.keys(ninguna.paths), [])
+})
+
+test('el árbol jerárquico está en el contrato, y con su recursión', () => {
+  // Es lo que pidió el operador: carpeta > … > colección > materiales por
+  // alumno. Si desapareciera del spec, la integración no sabría que existe.
+  assert.ok(spec.components.schemas.TreeNode)
+  assert.ok(spec.components.schemas.TreeFolder.properties.children.items.$ref
+    .endsWith('/TreeNode'), 'una carpeta tiene que poder contener otra carpeta')
+  assert.equal(
+    spec.paths['/api/v1/reports/students'].get.responses['200']
+      .content['application/json'].schema.properties.students.items.$ref,
+    '#/components/schemas/StudentCourseReport'
+  )
+  assert.ok(spec.components.schemas.StudentCourseReport.properties.tree)
+})
+
+test('el probador jamás ofrece escribir con el token de contenido', async () => {
+  // `CONTENT_API_TOKEN` suplanta a cualquier profesor: un formulario que invite
+  // a pegarlo en un navegador lo deja en el historial de un portátil ajeno.
+  const code = (await readFile(path.join(root, 'src/ui/assets/openapi.js'), 'utf8'))
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+  assert.match(code, /const probable = metodo === 'get' && esInforme\(ruta\)/)
+  assert.doesNotMatch(code, /localStorage|sessionStorage/,
+    'el token de prueba no se guarda en ninguna parte')
+  assert.doesNotMatch(code, /innerHTML/)
+})

--- a/test/report-tree.test.js
+++ b/test/report-tree.test.js
@@ -1,0 +1,185 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildReportTree } from '../src/services/report-tree.js'
+
+const ANA = 'profe-ana'
+const LUIS = 'profe-luis'
+
+/** Álgebra > Tema 2, de Ana. */
+const RUTAS = new Map([
+  ['carpeta-tema2', {
+    id: 'carpeta-tema2',
+    ownerSub: ANA,
+    ownerName: 'Ana Ruiz',
+    shared: false,
+    segments: [
+      { id: 'carpeta-algebra', name: 'Álgebra' },
+      { id: 'carpeta-tema2', name: 'Tema 2' }
+    ]
+  }],
+  ['carpeta-luis', {
+    id: 'carpeta-luis',
+    ownerSub: LUIS,
+    ownerName: 'Luis Prats',
+    shared: false,
+    segments: [{ id: 'carpeta-luis', name: 'Borradores baja de Luis' }]
+  }],
+  ['carpeta-compartida', {
+    id: 'carpeta-compartida',
+    ownerSub: LUIS,
+    ownerName: 'Luis Prats',
+    shared: true,
+    segments: [{ id: 'carpeta-compartida', name: 'Departamento' }]
+  }]
+])
+
+function actividadColeccion (extra = {}) {
+  return {
+    key: 'collection:col-1',
+    kind: 'collection',
+    id: 'col-1',
+    title: 'Prácticas',
+    historical: false,
+    folderId: 'carpeta-tema2',
+    owner: { sub: ANA, name: 'Ana Ruiz' },
+    items: [
+      { kind: 'video', id: 'vid-1', title: 'Intro', durationSeconds: 600, pageCount: null },
+      { kind: 'pdf', id: 'doc-1', title: 'Enunciados', durationSeconds: null, pageCount: 24 }
+    ],
+    ...extra
+  }
+}
+
+test('el árbol reproduce la biblioteca: carpeta > carpeta > colección > materiales', () => {
+  const tree = buildReportTree({ activities: [actividadColeccion()], folderPaths: RUTAS })
+
+  assert.equal(tree.length, 1)
+  const algebra = tree[0]
+  assert.equal(algebra.type, 'folder')
+  assert.equal(algebra.name, 'Álgebra')
+
+  const tema2 = algebra.children[0]
+  assert.equal(tema2.name, 'Tema 2')
+
+  const coleccion = tema2.children[0]
+  assert.equal(coleccion.type, 'collection')
+  assert.equal(coleccion.title, 'Prácticas')
+  // El orden de la colección es el que compuso el profesor, no alfabético.
+  assert.deepEqual(coleccion.items.map((i) => i.id), ['vid-1', 'doc-1'])
+  assert.deepEqual(coleccion.items.map((i) => i.kind), ['video', 'pdf'])
+})
+
+test('la carpeta privada de otro profesor no se le enseña a un compañero de aula', () => {
+  // ADR-016: el árbol es organización privada. «Borradores baja de Luis» es
+  // información del claustro, no del curso. El material sí sale —es del aula—,
+  // pero colgado de un nodo que dice de quién es y nada más.
+  const actividad = {
+    key: 'video:vid-9',
+    kind: 'video',
+    id: 'vid-9',
+    title: 'Repaso',
+    historical: false,
+    folderId: 'carpeta-luis',
+    owner: { sub: LUIS, name: 'Luis Prats' }
+  }
+
+  const comoAna = buildReportTree({ activities: [actividad], folderPaths: RUTAS, viewerSub: ANA })
+  assert.equal(comoAna[0].restricted, true)
+  assert.equal(comoAna[0].name, 'Biblioteca de Luis Prats')
+  assert.equal(comoAna[0].children[0].id, 'vid-9')
+  assert.doesNotMatch(JSON.stringify(comoAna), /Borradores/)
+
+  // Su dueño sí ve su propia ruta.
+  const comoLuis = buildReportTree({ activities: [actividad], folderPaths: RUTAS, viewerSub: LUIS })
+  assert.equal(comoLuis[0].name, 'Borradores baja de Luis')
+  assert.equal(comoLuis[0].restricted, false)
+
+  // Y el operador (consola de admin, API de informes) lo ve todo.
+  const comoOperador = buildReportTree({ activities: [actividad], folderPaths: RUTAS })
+  assert.equal(comoOperador[0].name, 'Borradores baja de Luis')
+})
+
+test('una carpeta compartida sí enseña su nombre al compañero (ADR-018)', () => {
+  const actividad = {
+    key: 'pdf:doc-7',
+    kind: 'pdf',
+    id: 'doc-7',
+    title: 'Temario',
+    historical: false,
+    folderId: 'carpeta-compartida',
+    owner: { sub: LUIS, name: 'Luis Prats' }
+  }
+  const tree = buildReportTree({ activities: [actividad], folderPaths: RUTAS, viewerSub: ANA })
+  assert.equal(tree[0].name, 'Departamento')
+  assert.equal(tree[0].restricted, false)
+})
+
+test('el material sin carpeta cuelga de «Sin carpeta», no de la raíz a secas', () => {
+  const tree = buildReportTree({
+    activities: [{
+      key: 'video:vid-2', kind: 'video', id: 'vid-2', title: 'Suelto',
+      historical: true, folderId: null, owner: { sub: ANA, name: 'Ana Ruiz' }
+    }],
+    folderPaths: RUTAS
+  })
+  assert.equal(tree[0].name, 'Sin carpeta')
+  assert.equal(tree[0].children[0].historical, true)
+})
+
+test('con el avance del alumno cada carpeta suma lo suyo', () => {
+  const progress = new Map([
+    ['vid-1', { materialId: 'vid-1', sessions: 3, downloads: 0, percent: 80, lastAt: '2026-08-20T10:00:00.000Z' }],
+    // El PDF no tiene telemetría: cuenta como acceso, pero NO como 0 %.
+    ['doc-1', { materialId: 'doc-1', sessions: 1, downloads: 2, percent: null, lastAt: '2026-08-22T09:00:00.000Z' }]
+  ])
+  const tree = buildReportTree({ activities: [actividadColeccion()], folderPaths: RUTAS, progress })
+
+  const coleccion = tree[0].children[0].children[0]
+  assert.deepEqual(coleccion.summary, {
+    materials: 2,
+    accessed: 2,
+    sessions: 4,
+    downloads: 2,
+    lastAt: '2026-08-22T09:00:00.000Z',
+    percent: 80
+  })
+  // La carpeta de arriba arrastra la suma de todo lo que cuelga de ella.
+  assert.equal(tree[0].summary.materials, 2)
+  assert.equal(tree[0].summary.sessions, 4)
+  assert.equal(tree[0].summary.percent, 80)
+
+  // Y cada hoja lleva su propia entrada, para no obligar a cruzar por id.
+  assert.equal(coleccion.items[0].progress.sessions, 3)
+  assert.equal(coleccion.items[1].progress.downloads, 2)
+})
+
+test('un alumno que no abrió nada sale igual, con ceros y sin porcentaje', () => {
+  const tree = buildReportTree({
+    activities: [actividadColeccion()], folderPaths: RUTAS, progress: new Map()
+  })
+  const coleccion = tree[0].children[0].children[0]
+  assert.equal(coleccion.summary.accessed, 0)
+  assert.equal(coleccion.summary.sessions, 0)
+  // Nunca «0 %»: no medido no es lo mismo que no visto (ADR-030).
+  assert.equal(coleccion.summary.percent, null)
+  assert.equal(coleccion.items[0].progress, null)
+})
+
+test('el andamio del cálculo no sale en el JSON', () => {
+  const json = JSON.stringify(buildReportTree({
+    activities: [actividadColeccion()], folderPaths: RUTAS, progress: new Map()
+  }))
+  assert.doesNotMatch(json, /indice/)
+  assert.doesNotMatch(json, /percents/)
+})
+
+test('las carpetas van antes que el material y en orden alfabético', () => {
+  const tree = buildReportTree({
+    activities: [
+      { key: 'video:z', kind: 'video', id: 'z', title: 'Zeta suelto', historical: false, folderId: null, owner: null },
+      actividadColeccion()
+    ],
+    folderPaths: RUTAS
+  })
+  assert.deepEqual(tree.map((n) => n.name), ['Álgebra', 'Sin carpeta'])
+})


### PR DESCRIPTION
Seguimiento de la serie #75–#79, tras probarla: un bug real y las tres cosas que
faltaban para poder integrar de verdad.

## 1 · El nombre del alumno no salía en el informe

Era una **cadena vacía**, no un `null`. Moodle omite los claims de nombre según
su configuración de privacidad y `toLaunchContext` devolvía `''` —el `?? ''`
final era código muerto, porque `join` nunca devuelve nullish—. Ese `''` es un
valor: atraviesa cualquier `?? null` y cualquier `a ?? b`, se guardó en los tres
eventos, y en la interfaz `name ?? identity ?? sub` lo dio por bueno. La celda
«Alumno» quedaba **en blanco** mientras el resto de la fila se pintaba bien.

La identidad tenía la otra mitad del mismo fallo: un parámetro personalizado mal
sustituido llega como `''` y `??` lo aceptaba, dejando el respaldo a
`lis_person_sourcedid` sin usar jamás.

El proyecto ya conocía el caso y lo resolvió bien una vez —`displayOwnerName`,
con truthiness—; el informe no reutilizó esa lección.

Se arregla en cuatro capas porque **las filas ya escritas en test y en producción
llevan el vacío guardado y no se tocan** (Regla 0): la raíz en `claims.js`, el
respaldo de identidad en `lti/routes.js`, `NULLIF(max(...), '')` en lado lectura,
y `etiquetaAlumno` en la interfaz, que cae al `sub` abreviado antes que dejar un
hueco.

Ninguna prueba lo cubría: la de integración localizaba siempre al alumno por
`sub`, y la única que miraba `user_name` fabricaba la sesión a mano sin pasar por
`toLaunchContext`. Ahora sí.

## 2 · El informe agregado y jerárquico (no estaba hecho)

`activities` y `materials` responden «¿qué ha visto?». El campo nuevo **`tree`**
responde «¿por dónde va?»: carpeta > carpeta > … > colección > materiales, con el
avance del alumno en cada hoja y la suma en cada nodo.

`tree` **se añade**; `activities` y `materials` salen igual, porque son contrato
ya emitido (Regla 0-bis). Lo monta `report-tree.js`, **puro** y probable sin
Postgres, sobre las rutas en segmentos de `folder-paths.js` —en segmentos y no
concatenadas, porque una carpeta llamada «Tema 3 / anexos» da una ruta ambigua—.

**La ruta de carpetas no es del curso, es del profesor.** El árbol es
organización privada (ADR-016) y el informe lo ve cualquier profesor del aula
(ADR-023): «Borradores baja de Ana» es información del claustro, no de la
asignatura. A un compañero se le enseña el material —eso sí es del curso— colgado
de un nodo `restricted` salvo que la carpeta esté compartida. Lo decide un
`viewerSub` que sale de la **sesión**. El operador no tiene ese recorte, igual que
ya ve todo el inventario en `/contenido`.

Un nodo sin telemetría no cuenta como 0 % en la media: no medido ≠ no visto.

## 3 · La consola de administración

`/admin/platforms/:id/seguimiento`: aulas de la instancia → informe del aula →
detalle de un alumno, y **búsqueda de un alumno por su username de Moodle** que
devuelve su avance en todas las aulas. Es una pantalla más, no una API nueva: los
datos van en el bootstrap y la autenticación es la cookie de administrador.
`REPORTS_API_TOKEN` no baja al navegador de nadie.

Queda escrito en `seguridad.md` que esta vista ve **más que cualquier profesor**
(todas las aulas de la instancia) y que no deja rastro en `admin_audit_event`,
porque la consola sólo audita escrituras. Auditarla o no es decisión del operador.

## 4 · Contrato OpenAPI y probador

`GET /api/v1/openapi.json` (OpenAPI 3.1) y `GET /api/v1/docs`.

- **Escrito a mano y en `src/api/`**, no en `docs/`: `.dockerignore` excluye
  `docs/` del build, así que un spec ahí no existiría en test ni en producción.
  Lo que impide que envejezca es `test/openapi.test.js`, que compara sus rutas
  con las que los routers registran de verdad.
- **Recortado a las APIs activas**: prometer una operación que va a responder 404
  porque su token no está puesto es peor que no documentarla.
- **No es Swagger UI**: ~12 MB y la primera dependencia de producción que
  existiría sólo para documentar, además de tener que comprobar si su bundle
  exige `'unsafe-eval'` contra una CSP que es `script-src 'self'` sin excepciones
  (T32). El probador propio sólo deja probar la **API de informes**; un formulario
  que invite a pegar `CONTENT_API_TOKEN` en un navegador deja en un historial
  ajeno una credencial que suplanta a cualquier profesor.

## Evidencia

- `npm run lint` limpio.
- `npm test`: **439/448** (9 saltados sin las herramientas del worker, esperado).
- `npm run test:integration`: **176/176** contra `moodleshield_test`.
- Comprobado **de punta a punta contra la aplicación corriendo**: `openapi.json`
  se sirve recortado a la API activa, `/api/v1/docs` responde 200 y su «Probar»
  devuelve HTTP 200 desde el navegador sin un solo error de consola; la API
  devuelve el árbol Álgebra > Tema 2 > Prácticas > vídeo + PDF con el avance del
  alumno; y `ip` / `user_agent` no aparecen en la respuesta.
- El módulo de la consola de administración se ejecutó en el navegador contra
  datos reales y pinta el árbol con las sumas por carpeta.

## Sin migraciones

Ninguna. El árbol se calcula, no se guarda; el arreglo del nombre es de lectura y
no toca ni una fila. `infra/prod/` intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VecRHroNGc9YmtDQDtHRb
