### PR TITLE
Colección Bruno para probar las dos APIs de /api/v1

### DIFF
--- a/docs/api-migracion-contenido.md
+++ b/docs/api-migracion-contenido.md
@@ -16,6 +16,10 @@ validaciones, las mismas tablas de trabajo y el mismo worker que la interfaz.
 > herramienta lo sirve en `GET /api/v1/openapi.json`, recortado a las APIs que ese
 > despliegue tiene activas, y lo enseña con un probador en `GET /api/v1/docs`.
 > Vive en `src/` y no aquí porque `.dockerignore` excluye `docs/` de la imagen.
+>
+> Para probar a mano hay una colección Bruno en
+> [`scripts/bruno/`](../scripts/bruno/README.md), con aserciones en cada petición
+> y los tokens como variables secretas —fuera del repositorio—.
 
 > [!WARNING]
 > `CONTENT_API_TOKEN` es una **credencial administrativa potente**: quien la tenga puede

--- a/scripts/bruno/Contenido/01 Plataformas.bru
+++ b/scripts/bruno/Contenido/01 Plataformas.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Plataformas
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/platforms
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+script:post-response {
+  // De aquí sale el UUID que hay que poner en platformId y en la cabecera
+  // X-MoodleShield-Platform-Id del resto de peticiones.
+  //
+  // `setVar` y NO `setEnvVar`: el segundo reescribe el fichero del entorno.
+  const plataformas = res.getBody()?.platforms
+  if (res.getStatus() === 200 && plataformas?.length && !bru.getEnvVar("platformId")) {
+    bru.setVar("platformId", plataformas[0].id)
+  }
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+}
+
+docs {
+  Para averiguar el UUID de cada instancia Moodle registrada.
+
+  Es la **única** operación de contenido que no exige las cabeceras de identidad:
+  con el bearer basta.
+
+  Si responde **404**, `CONTENT_API_TOKEN` está vacío y toda la API de contenido
+  está deshabilitada.
+}

--- a/scripts/bruno/Contenido/02 Plan de importacion.bru
+++ b/scripts/bruno/Contenido/02 Plan de importacion.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Plan de importacion
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/imports/plan
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+  ~X-MoodleShield-Owner-Name: Ada Lovelace
+}
+
+body:json {
+  {
+    "parentId": null,
+    "dryRun": true,
+    "entries": [
+      { "path": "Álgebra/Tema 1/clase.mp4", "size": 734003200 },
+      { "path": "Álgebra/Tema 1/apuntes.pdf", "size": 1048576 },
+      { "path": "Álgebra/Tema 1/.DS_Store", "size": 6148 }
+    ]
+  }
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+
+  test("los ocultos se omiten", function () {
+    const entradas = res.getBody().entries
+    expect(entradas.find((e) => e.index === 2).status).to.equal("skipped")
+  })
+}
+
+docs {
+  Reparte un árbol de directorios en carpetas y decide, fichero a fichero, qué es
+  **alta** y qué es **revisión**. Se le manda sólo la lista de rutas relativas.
+
+  **`dryRun: true` viene puesto a propósito**: resuelve el mismo reparto sin
+  crear ninguna carpeta, que es lo que quieres para mirar antes de tocar nada.
+  Ponlo a `false` cuando vayas en serio.
+
+  Lo importante del resultado: si la ruta repite un título ya presente en esa
+  carpeta, `materialId` viene con el UUID del material existente. Eso es una
+  **revisión, y el UUID no cambia** — por eso reimportar una carpeta corregida
+  actualiza las actividades Moodle ya creadas (ADR-025).
+
+  Se omiten ocultos (`.` inicial, `__MACOSX`, `Thumbs.db`) y todo lo que no sea
+  vídeo o PDF. Tope `MAX_IMPORT_ENTRIES` (500 por defecto): pasado, responde
+  **413 `too_many_entries`** y no crea nada.
+}

--- a/scripts/bruno/Contenido/03 Reservar una subida.bru
+++ b/scripts/bruno/Contenido/03 Reservar una subida.bru
@@ -1,0 +1,73 @@
+meta {
+  name: Reservar una subida
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/uploads
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+  ~X-MoodleShield-Owner-Name: Ada Lovelace
+}
+
+body:json {
+  {
+    "kind": "video",
+    "filename": "tema-01.mp4",
+    "size": 1048576,
+    "title": "Tema 1",
+    "description": "Introducción",
+    "folderId": null,
+    "materialId": null
+  }
+}
+
+script:post-response {
+  // Encadena con las peticiones 04-07 sin copiar identificadores a mano.
+  // `setVar` y NO `setEnvVar`: el segundo reescribe el fichero del entorno.
+  if (res.getStatus() === 201) {
+    bru.setVar("uploadId", res.getBody().uploadId)
+    bru.setVar("materialId", res.getBody().materialId)
+  }
+}
+
+tests {
+  test("responde 201", function () {
+    expect(res.getStatus()).to.equal(201)
+  })
+
+  test("dice el tamaño exacto de fragmento", function () {
+    expect(res.getBody().chunkBytes).to.be.a("number")
+  })
+}
+
+docs {
+  Reserva una sesión de subida y devuelve `uploadId`, `materialId`, `chunkBytes`,
+  `chunkCount`, `expiresAt` y la lista `received`.
+
+  El `size` de ejemplo es de 1 MiB —un solo fragmento— para que se pueda recorrer
+  el protocolo entero sin reservar cuota de verdad. Un vídeo real son cientos de
+  megas y varias decenas de fragmentos.
+
+  Para **sustituir el fichero de un material existente sin romper las
+  actividades Moodle**, pon su UUID en `materialId`. El propietario y la
+  plataforma deben coincidir.
+
+  Dos respuestas que **no son errores, son espera**:
+
+  - **429** — cuota por propietario agotada (subidas activas, bytes reservados…).
+  - **507** — sin espacio: cuota de almacenamiento o disco del servidor.
+
+  En los dos casos: para, resuelve lo que dice el aviso y vuelve a pedir el plan.
+  Las carpetas se reutilizan y sólo subirás lo que falte.
+}

--- a/scripts/bruno/Contenido/04 Estado de la subida.bru
+++ b/scripts/bruno/Contenido/04 Estado de la subida.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Estado de la subida
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/uploads/{{uploadId}}
+  body: none
+  auth: bearer
+}
+
+params:path {
+  uploadId: {{uploadId}}
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+}
+
+docs {
+  Qué fragmentos han llegado ya. Es lo que permite **reanudar** una transferencia
+  interrumpida, durante 24 horas por defecto.
+
+  `received` son los índices recibidos: manda sólo los que falten.
+}

--- a/scripts/bruno/Contenido/05 Subir un fragmento.bru
+++ b/scripts/bruno/Contenido/05 Subir un fragmento.bru
@@ -1,0 +1,54 @@
+meta {
+  name: Subir un fragmento
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{baseUrl}}/api/v1/uploads/{{uploadId}}/chunks/0
+  body: none
+  auth: bearer
+}
+
+params:path {
+  uploadId: {{uploadId}}
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+  Content-Type: application/octet-stream
+}
+
+docs {
+  **Esta petición está a medias a propósito: elige el fichero tú.**
+
+  El cuerpo son bytes crudos, así que Bruno no puede llevarlo en el `.bru` sin
+  incrustar un binario en el repositorio. Abre la pestaña **Body**, cambia el
+  tipo a **File / Binary** y escoge el fragmento. Cambia también el `0` final de
+  la URL por el índice que toque.
+
+  El tamaño exacto de cada fragmento lo dijo la reserva en `chunkBytes` (16 MiB
+  por defecto); todos son de ese tamaño salvo el último. Un fragmento mayor que
+  `UPLOAD_CHUNK_BYTES` recibe **413**.
+
+  > **Para una migración de verdad, no uses esto.** Trocear un fichero de 700 MB
+  > a mano no tiene ninguna gracia y un cliente gráfico mantiene el fichero en
+  > memoria. Está `scripts/upload-content.sh`, que hace el flujo entero por
+  > streaming:
+  >
+  > ```sh
+  > export MOODLESHIELD_URL=https://shield.example
+  > export CONTENT_API_TOKEN='...'
+  > export PLATFORM_ID='...'
+  > export OWNER_SUB='profesor-123'
+  > ./scripts/upload-content.sh export/tema-01.mp4
+  > ```
+  >
+  > Esta colección sirve para **entender y probar** el protocolo, no para mover
+  > gigabytes.
+}

--- a/scripts/bruno/Contenido/06 Completar la subida.bru
+++ b/scripts/bruno/Contenido/06 Completar la subida.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Completar la subida
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/v1/uploads/{{uploadId}}/complete
+  body: none
+  auth: bearer
+}
+
+params:path {
+  uploadId: {{uploadId}}
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+}
+
+tests {
+  test("responde 202 · encolado", function () {
+    expect(res.getStatus()).to.equal(202)
+  })
+}
+
+docs {
+  Reintegra el fichero y crea, **en una sola transacción**, el material, su
+  revisión y el trabajo pendiente. Responde `202` con `status: "queued"`.
+
+  **409 `revision_in_progress`** significa que ese material ya tiene una
+  candidata en cola: sólo se admite una a la vez. Espera a que termine o
+  descarta la candidata.
+
+  > **Si esto falla, cancela la sesión** (petición 07). Un `complete` fallido
+  > **no** libera la reserva, y unas pocas sesiones abandonadas agotan
+  > `MAX_ACTIVE_UPLOADS_PER_OWNER` hasta que caducan solas.
+}

--- a/scripts/bruno/Contenido/07 Cancelar la subida.bru
+++ b/scripts/bruno/Contenido/07 Cancelar la subida.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Cancelar la subida
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/uploads/{{uploadId}}
+  body: none
+  auth: bearer
+}
+
+params:path {
+  uploadId: {{uploadId}}
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+}
+
+tests {
+  test("responde 204", function () {
+    expect(res.getStatus()).to.equal(204)
+  })
+}
+
+docs {
+  Cancela la sesión y libera su reserva de cuota.
+
+  Cancela **una subida a medias**, no un material publicado: aquí no se borra
+  nada de lo que ya está sirviendo a un alumno.
+
+  Es la limpieza obligatoria después de un `complete` fallido.
+}

--- a/scripts/bruno/Contenido/08 Estado del material.bru
+++ b/scripts/bruno/Contenido/08 Estado del material.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Estado del material
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/api/v1/materials/{{materialKind}}/{{materialId}}
+  body: none
+  auth: bearer
+}
+
+params:path {
+  materialKind: {{materialKind}}
+  materialId: {{materialId}}
+}
+
+auth:bearer {
+  token: {{contentToken}}
+}
+
+headers {
+  X-MoodleShield-Platform-Id: {{platformId}}
+  X-MoodleShield-Owner-Sub: {{ownerSub}}
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+}
+
+docs {
+  Estado del material, su última revisión y el trabajo que la procesa. Es lo que
+  se consulta en bucle para observar una importación.
+
+  `materialKind` es `video` o `pdf`.
+
+  **En una sustitución hay que mirar `latestRevisionPublished`, no
+  `published`.** El material puede seguir `published: true` mientras la revisión
+  **anterior** protege a las actividades existentes: hasta que la nueva no se
+  activa, el alumno sigue viendo la vieja, que es justo lo que se quiere.
+
+  Estados terminales esperables de la última revisión: `ready`, `failed` o
+  `cancelled`.
+}

--- a/scripts/bruno/Contenido/folder.bru
+++ b/scripts/bruno/Contenido/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Contenido
+  seq: 3
+}

--- a/scripts/bruno/Contrato/01 Contrato OpenAPI.bru
+++ b/scripts/bruno/Contrato/01 Contrato OpenAPI.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Contrato OpenAPI
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/openapi.json
+  body: none
+  auth: none
+}
+
+tests {
+  test("responde 200 · hay al menos una API activa", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+
+  test("es OpenAPI 3.1", function () {
+    expect(res.getBody().openapi).to.match(/^3\.1/)
+  })
+
+  test("sólo promete lo que este despliegue sirve", function () {
+    // El spec se recorta a las APIs activas: prometer una operación que va a
+    // responder 404 porque su token no está puesto es peor que no documentarla.
+    const rutas = Object.keys(res.getBody().paths)
+    expect(rutas.length).to.be.above(0)
+  })
+}
+
+docs {
+  El contrato de `/api/v1`, servido por la propia herramienta y **sin token**.
+
+  Se recorta a las APIs que ese despliegue tiene activas. Si responde **404** no
+  hay ninguna: falta poner `REPORTS_API_TOKEN` o `CONTENT_API_TOKEN` en el
+  entorno de la aplicación.
+
+  `servers[0].url` viene resuelto con el origen público real de la petición, que
+  es lo correcto cuando la herramienta responde por varios nombres.
+
+  Hay un lector con probador en `{{baseUrl}}/api/v1/docs`.
+}

--- a/scripts/bruno/Contrato/folder.bru
+++ b/scripts/bruno/Contrato/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Contrato
+  seq: 1
+}

--- a/scripts/bruno/Informes/01 Aulas conocidas.bru
+++ b/scripts/bruno/Informes/01 Aulas conocidas.bru
@@ -1,0 +1,60 @@
+meta {
+  name: Aulas conocidas
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/reports/courses?platformId={{platformId}}
+  body: none
+  auth: bearer
+}
+
+params:query {
+  platformId: {{platformId}}
+}
+
+auth:bearer {
+  token: {{reportsToken}}
+}
+
+script:post-response {
+  // Si no habías fijado un aula, coge la primera: así las peticiones de abajo
+  // funcionan sin tener que copiar identificadores a mano.
+  //
+  // `setVar` y NO `setEnvVar`: el segundo reescribe el fichero del entorno, y
+  // acabaría dejando en el repositorio el identificador de un aula real.
+  const cursos = res.getBody()?.courses
+  if (res.getStatus() === 200 && cursos?.length && !bru.getEnvVar("contextId")) {
+    bru.setVar("contextId", cursos[0].contextId)
+  }
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+
+  test("devuelve la lista de aulas", function () {
+    expect(res.getBody().courses).to.be.an("array")
+  })
+}
+
+docs {
+  Las aulas que esta herramienta conoce de una instancia Moodle: las que dejaron
+  título en un launch **más** las que tienen material desplegado.
+
+  Tope fijo de 200 y **sin paginación**: es un índice, no un exportador.
+
+  La plataforma viaja por query y no por cabecera porque aquí no hay sesión LTI
+  de la que sacarla.
+
+  Errores que conviene distinguir:
+
+  - **400** — falta `platformId` o no es un UUID.
+  - **401** — el bearer no es el de esta API. Ojo: `contentToken` **no** vale.
+  - **403** — el token no está autorizado para esa plataforma
+    (`reports_api_platform_not_allowed`, por `REPORTS_API_ALLOWED_PLATFORM_IDS`).
+  - **404** — la plataforma no existe o está deshabilitada… **o la API entera lo
+    está**, porque `REPORTS_API_TOKEN` está vacío.
+}

--- a/scripts/bruno/Informes/02 Informe de un aula.bru
+++ b/scripts/bruno/Informes/02 Informe de un aula.bru
@@ -1,0 +1,76 @@
+meta {
+  name: Informe de un aula
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/reports/courses/{{contextId}}?platformId={{platformId}}
+  body: none
+  auth: bearer
+}
+
+params:query {
+  platformId: {{platformId}}
+}
+
+params:path {
+  contextId: {{contextId}}
+}
+
+auth:bearer {
+  token: {{reportsToken}}
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+
+  test("trae la matriz y el árbol", function () {
+    const body = res.getBody()
+    expect(body.activities).to.be.an("array")
+    expect(body.materials).to.be.an("array")
+    expect(body.students).to.be.an("array")
+    expect(body.tree).to.be.an("array")
+  })
+
+  test("el árbol del aula es estructura, sin avance en las hojas", function () {
+    // El avance por alumno vive en students[].materials, indexado por materialId.
+    const hojas = []
+    const recorre = (nodos) => nodos.forEach((n) => {
+      if (n.type === "material") hojas.push(n)
+      recorre(n.children ?? n.items ?? [])
+    })
+    recorre(res.getBody().tree)
+    hojas.forEach((hoja) => expect(hoja).to.not.have.property("progress"))
+  })
+
+  test("ni ip ni user_agent salen por aquí", function () {
+    // Son del registro forense, no del seguimiento docente (ADR-030).
+    expect(JSON.stringify(res.getBody())).to.not.match(/user_?[Aa]gent|"ip"/)
+  })
+}
+
+docs {
+  El informe completo de un aula: **exactamente el mismo JSON** que ve el
+  profesor dentro de la herramienta.
+
+  Topes: 500 alumnos y 200 materiales.
+
+  Un `contextId` desconocido responde **200 con un informe vacío**, no 404: para
+  un integrador «esa aula todavía no tiene nada» es una respuesta legítima. El
+  404 sólo aparece si el identificador pasa de 512 caracteres.
+
+  Tres campos que conviene mirar antes de escribir código contra esto:
+
+  - `telemetry.{opensSince, videoStatsSince, pdfStatsSince}` — desde cuándo hay
+    dato de cada tipo. `null` en un avance significa **no medido**, que no es lo
+    mismo que cero: pintar «0 %» sobre un material que un alumno vio antes de
+    este despliegue sería una acusación falsa.
+  - `activities[].historical` — tiene accesos pero ningún despliegue vivo lo
+    explica: actividades anteriores a la migración 014, o material retirado del
+    aula. Cuenta igual, sin reinsertar nada.
+  - `tree` — el mismo material con la forma de la biblioteca del profesor. Aquí
+    es **sólo estructura**; el avance está en `students[]`.
+}

--- a/scripts/bruno/Informes/03 Alumno por username.bru
+++ b/scripts/bruno/Informes/03 Alumno por username.bru
@@ -1,0 +1,84 @@
+meta {
+  name: Alumno por username
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/reports/students?platformId={{platformId}}&identity={{identity}}
+  body: none
+  auth: bearer
+}
+
+params:query {
+  platformId: {{platformId}}
+  identity: {{identity}}
+  ~sub:
+  ~contextId: {{contextId}}
+}
+
+auth:bearer {
+  token: {{reportsToken}}
+}
+
+tests {
+  test("responde 200", function () {
+    expect(res.getStatus()).to.equal(200)
+  })
+
+  test("sin coincidencia devuelve lista vacía, nunca 404", function () {
+    expect(res.getBody().students).to.be.an("array")
+  })
+
+  test("si hay alumno, su árbol lleva el avance en cada hoja", function () {
+    const alumno = res.getBody().students[0]
+    if (!alumno) return
+    expect(alumno.tree).to.be.an("array")
+    const hojas = []
+    const recorre = (nodos) => nodos.forEach((n) => {
+      if (n.type === "material") hojas.push(n)
+      recorre(n.children ?? n.items ?? [])
+    })
+    recorre(alumno.tree)
+    hojas.forEach((hoja) => expect(hoja).to.have.property("progress"))
+  })
+
+  test("ni ip ni user_agent salen por aquí", function () {
+    expect(JSON.stringify(res.getBody())).to.not.match(/user_?[Aa]gent|"ip"/)
+  })
+}
+
+docs {
+  **Ésta es la pregunta que responde el informe agregado**: «¿por dónde va este
+  alumno?», buscándolo por su **nombre de usuario de Moodle**.
+
+  Devuelve una entrada por cada aula donde tenga rastro (tope 20). Cada una trae
+  la matriz plana (`materials`, `activities`, `progress`, `timeline`) y, además,
+  un **`tree`** con la forma de la biblioteca del profesor —carpeta > carpeta >
+  … > colección > materiales—, con el avance de ese alumno en cada hoja y la
+  suma en cada nodo:
+
+  ```
+  folder  Álgebra                    2/2 abiertos · 3 sesiones · 42 %
+  └ folder  Tema 2                   2/2 abiertos · 3 sesiones · 42 %
+    └ collection  Prácticas del Tema 2
+      ├ video  Derivadas: introducción   6:12 de 10:00 · 62 % · 2 sesiones
+      └ pdf    Boletín de ejercicios     5/24 pág. · 1 descarga
+  ```
+
+  Se puede buscar por `identity` (username, sin distinguir mayúsculas) **o** por
+  `sub` (el identificador LTI). Uno de los dos es obligatorio; si no mandas
+  ninguno son **400**. `contextId` es opcional y acota a un aula: los dos vienen
+  desactivados con `~` — actívalos en la pestaña Query si los necesitas.
+
+  Sin coincidencia responde `{"students": []}`, **nunca 404**: para la
+  herramienta externa «todavía no ha abierto nada» es una respuesta legítima.
+
+  Al consumirlo, tres cosas:
+
+  - **`percent: null` significa «no medido», no cero.**
+  - **El orden de `items` de una colección es el que compuso el profesor**, no
+    alfabético.
+  - `summary.percent` de una carpeta es la media de los materiales **con** dato:
+    uno sin telemetría no arrastra la media a cero.
+}

--- a/scripts/bruno/Informes/folder.bru
+++ b/scripts/bruno/Informes/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Informes
+  seq: 2
+}

--- a/scripts/bruno/README.md
+++ b/scripts/bruno/README.md
@@ -1,0 +1,107 @@
+# Colección Bruno de `/api/v1`
+
+Para probar a mano las dos APIs de integración: **informes** (sólo lectura) y
+**contenido** (escritura). [Bruno](https://www.usebruno.com) guarda las
+colecciones como ficheros de texto, así que ésta vive en el repositorio y se
+revisa como cualquier otro cambio.
+
+## Abrirla
+
+En la aplicación de escritorio: **Open Collection** → elige este directorio
+(`scripts/bruno`).
+
+## Rellenar el entorno
+
+Arriba a la derecha, elige `local` o `test` y edítalo. Las variables normales van
+en el fichero; **los dos tokens son `vars:secret`**, que Bruno guarda fuera del
+repositorio, así que rellenarlos aquí no los publica.
+
+| Variable | Qué es | Cómo lo consigues |
+|---|---|---|
+| `baseUrl` | Origen de la herramienta | `http://localhost:3000` en local; en `test`, tu dominio |
+| `reportsToken` | `REPORTS_API_TOKEN` | Del `.env` del entorno |
+| `contentToken` | `CONTENT_API_TOKEN` | Del `.env` del entorno |
+| `platformId` | UUID de la instancia Moodle | Lo rellena sola *Contenido → Plataformas* |
+| `contextId` | Aula de Moodle | Lo rellena sola *Informes → Aulas conocidas* |
+| `identity` | Username de Moodle de un alumno | El que quieras consultar |
+| `ownerSub` | `sub` LTI del profesor propietario | Sólo para la API de contenido |
+
+Empieza por **Informes → Aulas conocidas**: si tienes `platformId`, deja
+`contextId` puesto para las demás.
+
+> Los dos tokens **no son intercambiables**. `reportsToken` sólo lee;
+> `contentToken` escribe eligiendo `owner_sub`, es decir, suplantando a cualquier
+> profesor. La aplicación rechaza el arranque si coinciden. Un 401 al usar uno
+> donde va el otro es el comportamiento correcto, no un fallo de la colección.
+
+## Un 404 puede significar «no está activada»
+
+Con su token vacío, cada API responde **404** en todas sus rutas: una API
+deshabilitada no se anuncia. Si *Aulas conocidas* da 404, lo primero que hay que
+mirar es si `REPORTS_API_TOKEN` está puesto en el entorno de la aplicación —no en
+Bruno—. Igual con `CONTENT_API_TOKEN` y la carpeta *Contenido*.
+
+`Contrato → Contrato OpenAPI` no lleva token y sirve para salir de dudas: dice
+qué APIs están activas en ese despliegue, porque el spec se recorta a ellas.
+
+## Desde la terminal
+
+Cada petición trae aserciones, así que la colección vale como **comprobación de
+humo** de un despliegue. Los tokens no viajan en el repositorio: pásalos con
+`--env-var`.
+
+```sh
+npx @usebruno/cli run Contrato Informes --env local -r \
+  --env-var baseUrl="$MOODLESHIELD_URL" \
+  --env-var reportsToken="$REPORTS_API_TOKEN" \
+  --env-var platformId="$PLATFORM_ID" \
+  --env-var identity=alumno.de.prueba
+```
+
+Eso sí sale entero en verde: son las trece aserciones de sólo lectura, incluida
+la de que **ni `ip` ni `user_agent` salen por la API de informes**. `contextId`
+lo rellena sola *Aulas conocidas* al pasar.
+
+*Contenido* **no puede salir entera en verde sin intervención**, y no es un
+fallo: el paso del fragmento lleva un fichero de verdad que esta colección no
+incluye. En una tanda automática verás exactamente esto, que es lo correcto:
+
+| Petición | Resultado | Por qué |
+|---|---|---|
+| 01 Plataformas | 200 | |
+| 02 Plan de importación | 200 | con `dryRun: true` no crea nada |
+| 03 Reservar una subida | 201 | |
+| 04 Estado de la subida | 200 | `received: []`, aún no ha llegado nada |
+| 05 Subir un fragmento | **400** | sin cuerpo binario; lo eliges tú |
+| 06 Completar la subida | **409** | no ha llegado ningún fragmento |
+| 07 Cancelar la subida | 204 | libera la reserva, como manda el protocolo |
+| 08 Estado del material | **404** | se acaba de cancelar: ese material no existe |
+
+Para probarla de verdad, recórrela a mano en la aplicación con un fichero
+pequeño. Lanzarla headless sigue valiendo para comprobar credenciales, cabeceras
+y cuotas:
+
+```sh
+npx @usebruno/cli run Contenido --env local -r \
+  --env-var baseUrl="$MOODLESHIELD_URL" \
+  --env-var contentToken="$CONTENT_API_TOKEN" \
+  --env-var platformId="$PLATFORM_ID" \
+  --env-var ownerSub="$OWNER_SUB"
+```
+
+Sin `ownerSub` la API de contenido responde **400**: exige
+`X-MoodleShield-Owner-Sub` en todas sus rutas salvo `/platforms`.
+
+## Lo que esta colección no hace
+
+**Subir un fichero de verdad.** `PUT …/chunks/{n}` lleva bytes crudos y hay que
+trocear el fichero; un cliente gráfico además lo mantiene en memoria. Para eso
+está [`scripts/upload-content.sh`](../upload-content.sh), que hace el flujo
+entero por streaming. Aquí el protocolo está para entenderlo y probarlo.
+
+## Documentación
+
+- [`docs/api-migracion-contenido.md`](../../docs/api-migracion-contenido.md) —
+  las dos APIs, con ejemplos y garantías.
+- `GET /api/v1/openapi.json` — el contrato, servido por la propia herramienta.
+- `GET /api/v1/docs` — el mismo contrato con un probador para la API de informes.

--- a/scripts/bruno/bruno.json
+++ b/scripts/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "MoodleShield",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/scripts/bruno/collection.bru
+++ b/scripts/bruno/collection.bru
@@ -1,0 +1,22 @@
+docs {
+  # MoodleShield · `/api/v1`
+
+  Dos APIs bajo el mismo prefijo, con **tokens distintos y no intercambiables**:
+
+  - **Informes** — sólo lectura, `REPORTS_API_TOKEN`. La que se integra con una
+    herramienta externa de seguimiento de alumnos.
+  - **Contenido** — escritura, `CONTENT_API_TOKEN`. Sube material **eligiendo
+    `owner_sub`**, es decir, suplantando a cualquier profesor. La aplicación
+    rechaza el arranque si los dos tokens coinciden.
+
+  Con su token sin configurar, cada superficie responde **404**, no 401: una API
+  deshabilitada no se anuncia. Un 404 aquí puede significar «no existe» o «no
+  está activada».
+
+  Los tokens son variables **secretas** del entorno: Bruno las guarda fuera de
+  estos ficheros, así que nunca acaban en el repositorio. Rellénalas en
+  Colección → Environments antes de lanzar nada.
+
+  El contrato completo lo sirve la propia herramienta en `/api/v1/openapi.json`,
+  y hay un lector con probador en `/api/v1/docs`.
+}

--- a/scripts/bruno/environments/local.bru
+++ b/scripts/bruno/environments/local.bru
@@ -1,0 +1,14 @@
+vars {
+  baseUrl: http://localhost:3000
+  platformId:
+  contextId:
+  identity:
+  ownerSub:
+  materialKind: video
+  materialId:
+  uploadId:
+}
+vars:secret [
+  reportsToken,
+  contentToken
+]

--- a/scripts/bruno/environments/test.bru
+++ b/scripts/bruno/environments/test.bru
@@ -1,0 +1,14 @@
+vars {
+  baseUrl: https://CAMBIAME.example
+  platformId:
+  contextId:
+  identity:
+  ownerSub:
+  materialKind: video
+  materialId:
+  uploadId:
+}
+vars:secret [
+  reportsToken,
+  contentToken
+]


### PR DESCRIPTION
Para probar a mano la API de informes y la de contenido. Bruno guarda las
colecciones como ficheros de texto, así que ésta vive en el repositorio y se
revisa como cualquier otro cambio.

Va en `scripts/bruno/`, junto a `upload-content.sh` que resuelve el mismo caso
desde la terminal. `COPY scripts/*.mjs` no arrastra subdirectorios, así que no
engorda la imagen.

## Tres decisiones

- **Los tokens son `vars:secret`.** Bruno los guarda fuera de estos ficheros, así
  que rellenarlos no los publica. Ninguna credencial entra en el repositorio.
- **`bru.setVar`, nunca `bru.setEnvVar`.** El segundo **reescribe el fichero del
  entorno**: la primera ejecución de prueba dejó dentro el `contextId` del aula
  sembrada, que es exactamente cómo un identificador real acabaría commiteado sin
  que nadie se diera cuenta.
- **La carpeta de contenido no puede salir verde headless, y el README lo
  tabula.** El paso del fragmento lleva un fichero de verdad que la colección no
  incluye: 05 da 400, 06 da 409 y 08 da 404 tras el cancelado. Está escrito para
  que nadie lo lea como avería. Para mover gigabytes sigue estando
  `upload-content.sh`, que va por streaming y no mantiene el fichero en memoria.

## Sirve como comprobación de humo

Cada petición trae aserciones, incluida la de que **ni `ip` ni `user_agent` salen
por la API de informes** (ADR-030), y la de que el árbol del aula es estructura
mientras el del alumno lleva el avance en cada hoja.

```sh
npx @usebruno/cli run Contrato Informes --env test -r \
  --env-var baseUrl="$MOODLESHIELD_URL" \
  --env-var reportsToken="$REPORTS_API_TOKEN" \
  --env-var platformId="$PLATFORM_ID" \
  --env-var identity=alumno.de.prueba
```

## Evidencia

Verificado con `@usebruno/cli` contra la aplicación corriendo y datos sembrados:

- `Contrato` + `Informes`: **13/13**, todo en verde.
- `Contenido`: plataformas 200, plan de importación 200 (con `dryRun`), reservar
  **201**, consultar estado **200**, cancelar **204**. Las tres que fallan son
  las documentadas arriba.
- Comprobado además que una ejecución **no reescribe** el fichero del entorno.

`npm run lint` limpio y `npm test` en 439/448 (9 saltados, esperado). No toca
código de la aplicación: sólo añade `scripts/bruno/` y una línea en
`docs/api-migracion-contenido.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VecRHroNGc9YmtDQDtHRb