### PR TITLE
Documentar cada variable del entorno y emitir las de la API de informes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,25 @@
 # Genera los secretos con:  openssl rand -hex 32
 # -----------------------------------------------------------------------------
 
+# 'development', 'test' o 'production'. Cualquier otro valor aborta el arranque.
+# Endurece medio sistema: exige HTTPS, secretos de 32 caracteres, MEDIA_DELIVERY
+# firmado y LAUNCH_RESOURCE_SIGNATURE=enforce. El entorno de pruebas TAMBIÉN
+# corre con 'production': se parece a producción a propósito.
 NODE_ENV=development
 LOG_LEVEL=debug
+
+# Qué papel juega ESTE proceso: 'app' (web), 'worker' (transcodifica) o
+# 'migrate' (sólo aplica migraciones y sale). El entrypoint arranca primero con
+# 'migrate' y quita del entorno las credenciales de DDL antes de iniciar la web,
+# para que el proceso que atiende peticiones no conserve autoridad de esquema.
+# No hace falta tocarla a mano: la ponen los scripts y el contenedor.
+SERVICE_ROLE=app
+
+# Etiqueta visible del entorno: 'test', 'prod'… Aparece en la barra de la consola
+# de administración. NODE_ENV no distingue test de producción —los dos son
+# 'production'— y esto sí: existe porque una tarde se fue en probar contra una
+# imagen que no era la que se creía.
+MOODLESHIELD_ENV=
 
 # URL pública tal y como la ve Moodle. En local con túnel, la del túnel.
 # Moodle exige HTTPS: ver docs/https-tunel.md
@@ -25,7 +42,12 @@ DB_APP_PASSWORD=moodleshield-app
 # El worker sólo recibe estas dos variables de base de datos.
 DB_WORKER_USER=moodleshield_worker
 DB_WORKER_PASSWORD=moodleshield-worker
+# Si el bootstrap crea los roles de app y worker con privilegios mínimos. En
+# desarrollo suele estar a false y la app usa el propietario; en producción los
+# crea el entrypoint. `DB_PROVISION_WORKER_ROLE` es el nombre antiguo y sigue
+# valiendo como respaldo, para no romper un stack desplegado con él.
 DB_PROVISION_SERVICE_ROLES=false
+DB_PROVISION_WORKER_ROLE=false
 
 # --- Secretos (obligatorios en producción, mínimo 32 caracteres) ---
 SESSION_SECRET=
@@ -37,15 +59,36 @@ MEDIA_LINK_SECRET=
 # Si se deja vacío, ese endpoint queda deshabilitado.
 LTI_ADMIN_TOKEN=
 
-# Token exclusivo para la API de migración (/api/v1). Vacío la deshabilita.
-# En producción debe contener al menos 32 caracteres: openssl rand -hex 32
+# --- APIs de integración (/api/v1) -------------------------------------------
+# Dos APIs bajo el mismo prefijo, con tokens DISTINTOS y no intercambiables.
+# Con su token vacío, cada una responde 404 en todas sus rutas: una API
+# deshabilitada no se anuncia. El contrato se sirve en /api/v1/openapi.json,
+# recortado a las que estén activas, y hay un lector en /api/v1/docs.
+#
+# OJO EN PRODUCCIÓN (y en test, que corre con NODE_ENV=production): poner un
+# token SIN su lista de plataformas aborta el arranque. Van las dos, o ninguna.
+
+# API de CONTENIDO: escritura. Sube material eligiendo `owner_sub`, es decir,
+# SUPLANTANDO A CUALQUIER PROFESOR. Déjala apagada fuera de una migración y
+# rota el token al terminar.
+#   · Genera el token con: openssl rand -hex 32
+#   · En producción: mínimo 32 caracteres.
 CONTENT_API_TOKEN=
+# UUID de las instancias Moodle que ese token puede tocar, separados por coma.
+# Una petición que declare otra recibe 403 aunque el bearer sea correcto.
+# Obligatoria en producción cuando hay token; sólo admite UUID.
 CONTENT_API_ALLOWED_PLATFORM_IDS=
 
-# Token de la API de informes (/api/v1/reports), SÓLO LECTURA. Vacío la
-# deshabilita (404). Tiene que ser distinto del de migración —ése escribe
-# suplantando al propietario— y la validación de arranque lo comprueba.
+# API de INFORMES: sólo lectura. Es la que se cruza con una herramienta externa
+# de seguimiento de alumnos. Devuelve nombre y username de Moodle —son la clave
+# del cruce— pero jamás `ip` ni `user_agent`, que son del registro forense
+# (ADR-030). Quien sólo consulta avances no debe sostener el token de contenido:
+# la validación de arranque rechaza que los dos sean iguales.
+#   · Genera el token con: openssl rand -hex 32
+#   · En producción: mínimo 32 caracteres.
 REPORTS_API_TOKEN=
+# Mismas reglas que la lista de contenido: UUID separados por coma, obligatoria
+# en producción cuando hay token, y fuera de ella responde 403.
 REPORTS_API_ALLOWED_PLATFORM_IDS=
 
 # --- Consola web de administración (/admin) ---
@@ -191,9 +234,12 @@ CDN_TRUSTED_RANGES=
 # No afecta a la subida de material: ésa va en streaming, sin pasar por aquí.
 BODY_LIMIT=256kb
 DB_POOL_MAX=6
-# Para una BD remota en producción se exige verify-full. DB_SSL_CA_FILE es
-# opcional si la CA ya está en el trust store de la imagen.
+# 'disable', 'require' o 'verify-full'. Para una BD remota en producción se
+# exige verify-full. DB_SSL_CA_FILE es opcional si la CA ya está en el trust
+# store de la imagen. `DB_SSL=true` es la forma antigua y sólo cambia el valor
+# por defecto de DB_SSL_MODE a 'require': si pones DB_SSL_MODE, manda éste.
 DB_SSL_MODE=disable
+DB_SSL=false
 DB_SSL_CA_FILE=
 LOG_PRETTY=true
 

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -138,8 +138,8 @@ Salida esperada: dos patrones distintos, del estilo `AABBBAAAAA` y `BBABABBAAB`.
 
 ```bash
 npm run lint              # ESLint
-npm test                  # 388 unitarias, sin base de datos (9 se saltan, ver abajo)
-npm run test:integration  # 154 contra Postgres real
+npm test                  # 453 unitarias, sin base de datos (9 se saltan, ver abajo)
+npm run test:integration  # 176 contra Postgres real
 npm run test:coverage     # cobertura nativa de node:test
 ```
 
@@ -353,6 +353,7 @@ Las que más se tocan durante el desarrollo:
 | `TRANSCODE_CONCURRENCY` | `1` | Debe permanecer en `1`: el arranque rechaza otro valor |
 | `CONTENT_API_TOKEN` | — | Activa la API de migración; vacío la mantiene en 404 |
 | `REPORTS_API_TOKEN` | — | Activa la API de informes (sólo lectura, [ADR-030](decisiones.md)); debe ser distinto del anterior |
+| `*_ALLOWED_PLATFORM_IDS` | — | UUID separados por coma. ⚠️ Con `NODE_ENV=production` —lo que usan **test y producción**— poner un token sin su lista **aborta el arranque**: van las dos, o ninguna |
 | `TRANSCODE_LEASE_SECONDS` | `90` | Plazo tras el que otro worker recupera un trabajo huérfano |
 | `LOG_LEVEL` | `info` | `debug` añade detalle operativo; las rutas sensibles se redactan en la rama endurecida |
 | `WATERMARK_SECRET` | — | ⚠️ **Permanente.** Cambiarlo invalida todas las trazas |

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -161,6 +161,8 @@ MEDIA_KEY_SECRET=$(gen)
 MEDIA_LINK_SECRET=$(gen)
 CONTENT_API_TOKEN=
 CONTENT_API_ALLOWED_PLATFORM_IDS=
+REPORTS_API_TOKEN=
+REPORTS_API_ALLOWED_PLATFORM_IDS=
 ADMIN_USERNAME=$ADMIN_USER
 ADMIN_PASSWORD_HASH=$ADMIN_PASSWORD_HASH
 ADMIN_SESSION_SECRET=$(gen)
@@ -213,8 +215,20 @@ adivinarlos:
                        instancia ya tenía alguno, VUELVE A PONERLO: sin él la
                        consola responde 403 al iniciar sesión, porque el Origin
                        del formulario no está en la lista blanca.
-  CONTENT_API_TOKEN    API de migración; se deja apagada. Actívala sólo durante
-                       una migración y acota con CONTENT_API_ALLOWED_PLATFORM_IDS.
+  CONTENT_API_TOKEN    API de migración (escribe). Se deja apagada: quien tenga
+                       ese token sube material eligiendo owner_sub, o sea,
+                       suplantando a cualquier profesor. Actívala sólo durante
+                       una migración, acótala con
+                       CONTENT_API_ALLOWED_PLATFORM_IDS y rótala al terminar.
+  REPORTS_API_TOKEN    API de informes (sólo lectura), para cruzar el avance de
+                       los alumnos con una herramienta externa. También se deja
+                       apagada. Tiene que ser DISTINTA del token de migración: si
+                       coinciden, la aplicación no arranca.
+
+Las dos listas de plataformas son UUID separados por coma, y aquí NO son
+opcionales: con NODE_ENV=production —que es lo que usan test y producción—
+poner un token sin su lista aborta el arranque. Van las dos, o ninguna. El UUID
+de cada instancia está en la consola, en la URL de su botón «Editar».
 
 Y uno que conviene revisar:
 

--- a/test/env-example.test.js
+++ b/test/env-example.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * `.env.example` no es un adorno: es la única lista de lo que se puede
+ * configurar, y `scripts/generate-env.sh` produce el bloque que se pega en
+ * Portainer. Cuando una variable nueva se queda fuera de los dos, nadie
+ * descubre que existe hasta que le hace falta — y para entonces está buscando
+ * por qué una API responde 404.
+ *
+ * Ya pasó con `REPORTS_API_TOKEN`: llegó al `.env.example` y al Compose, pero no
+ * al generador, que es justo el fichero del que sale la configuración real de
+ * test y de producción.
+ *
+ * El propio `.env.example` lo dice: «se listan porque `src/config.js` los lee y
+ * conviene que no haya configuración invisible». Esto lo hace cumplir.
+ */
+
+const config = await readFile(path.join(root, 'src/config.js'), 'utf8')
+const ejemplo = await readFile(path.join(root, '.env.example'), 'utf8')
+const generador = await readFile(path.join(root, 'scripts/generate-env.sh'), 'utf8')
+
+/** Las variables que `src/config.js` lee del entorno, por sus helpers. */
+function variablesLeidas (source) {
+  const nombres = new Set()
+  const helpers = /(?:required|optional|integer|bool|list|secret)\(\s*'([A-Z0-9_]+)'/g
+  for (const [, nombre] of source.matchAll(helpers)) nombres.add(nombre)
+  return nombres
+}
+
+/** Las claves declaradas en un fichero con formato dotenv. */
+function clavesDeclaradas (source) {
+  return new Set(
+    source.split('\n')
+      .filter((linea) => /^[A-Z0-9_]+=/.test(linea))
+      .map((linea) => linea.slice(0, linea.indexOf('=')))
+  )
+}
+
+test('todo lo que config.js lee del entorno está en .env.example', () => {
+  const declaradas = clavesDeclaradas(ejemplo)
+  const faltan = [...variablesLeidas(config)].filter((nombre) => !declaradas.has(nombre)).sort()
+  assert.deepEqual(faltan, [],
+    'variables que la aplicación lee y .env.example no documenta')
+})
+
+test('cada variable de .env.example lleva su comentario', () => {
+  // Una clave suelta sin explicación obliga a leer `src/config.js` para saber
+  // qué hace, que es exactamente lo que este fichero existe para evitar.
+  const lineas = ejemplo.split('\n')
+  const sinComentario = []
+  for (let i = 0; i < lineas.length; i++) {
+    if (!/^[A-Z0-9_]+=/.test(lineas[i])) continue
+    // Vale un comentario propio arriba, o compartir el de una clave anterior
+    // del mismo bloque (lo normal en pares como USER/PASSWORD).
+    let j = i - 1
+    while (j >= 0 && /^[A-Z0-9_]+=/.test(lineas[j])) j--
+    if (j < 0 || !lineas[j].trimStart().startsWith('#')) {
+      sinComentario.push(lineas[i].slice(0, lineas[i].indexOf('=')))
+    }
+  }
+  assert.deepEqual(sinComentario, [], 'claves de .env.example sin ningún comentario que las explique')
+})
+
+test('el generador de Portainer emite los tokens de las dos APIs', () => {
+  // Es el fichero del que sale la configuración real de test y producción.
+  // Que una API esté en `.env.example` y no aquí es cómo se pierde media tarde.
+  const emitidas = clavesDeclaradas(generador)
+  for (const nombre of [
+    'CONTENT_API_TOKEN',
+    'CONTENT_API_ALLOWED_PLATFORM_IDS',
+    'REPORTS_API_TOKEN',
+    'REPORTS_API_ALLOWED_PLATFORM_IDS'
+  ]) {
+    assert.ok(emitidas.has(nombre), `scripts/generate-env.sh no emite ${nombre}`)
+  }
+})
+
+test('el generador deja las dos APIs apagadas', () => {
+  // `CONTENT_API_TOKEN` suplanta a cualquier profesor y el de informes lee datos
+  // personales de alumnos: ninguno se enciende solo al crear un entorno.
+  for (const nombre of ['CONTENT_API_TOKEN', 'REPORTS_API_TOKEN']) {
+    assert.match(generador, new RegExp(`^${nombre}=$`, 'm'),
+      `${nombre} tiene que salir vacío del generador`)
+  }
+})
+
+test('.env.example avisa de que un token sin su lista aborta el arranque', () => {
+  // La trampa que se lleva un despliegue por delante: en producción —y test
+  // corre con NODE_ENV=production— poner el token sin la allowlist impide
+  // arrancar. `assertConfigValid` lo comprueba; aquí se comprueba que se avisa.
+  assert.match(config, /REPORTS_API_TOKEN en producción exige REPORTS_API_ALLOWED_PLATFORM_IDS/)
+  assert.match(ejemplo, /Van las dos, o ninguna/)
+  assert.match(generador, /Van las dos, o ninguna/)
+})


### PR DESCRIPTION
Tres agujeros que salieron al configurar TEST para usar la API de informes.

## 1 · El generador de Portainer no emitía `REPORTS_API_*`

`scripts/generate-env.sh` es el fichero del que sale el bloque que se pega en
Portainer: **la configuración real de test y de producción**. La API de informes
llegó al `.env.example` y al Compose de test, pero no aquí, así que quien crea un
entorno nuevo no tiene forma de enterarse de que existe.

Ahora emite las cuatro claves de las dos APIs, **vacías** —ninguna se enciende
sola— y la ayuda por stderr explica el alcance de cada token: el de contenido
sube material eligiendo `owner_sub`, es decir, suplantando a cualquier profesor.

## 2 · La trampa que tumba un despliegue no estaba escrita

Con `NODE_ENV=production` —que es lo que usan **test y producción**— poner un
token sin su `*_ALLOWED_PLATFORM_IDS` **aborta el arranque**. `assertConfigValid`
lo comprueba desde el primer día; en ningún sitio se avisaba.

Ahora lo dicen `.env.example`, el generador y `docs/desarrollo.md`, con la misma
frase: **van las dos, o ninguna**.

## 3 · Cuatro variables sin documentar

`SERVICE_ROLE`, `MOODLESHIELD_ENV`, `DB_SSL` y `DB_PROVISION_WORKER_ROLE`: las lee
`src/config.js` y no estaban en `.env.example`. El propio fichero promete que no
hay «configuración invisible»; no la había por descuido, no por diseño.

## Lo que impide que vuelva a pasar

`test/env-example.test.js`:

- toda variable que la aplicación lee está en `.env.example`;
- toda clave del `.env.example` lleva comentario;
- el generador emite los tokens de las dos APIs **y los deja apagados**;
- el aviso de «un token sin su lista aborta el arranque» sigue en los tres sitios.

Comprobado que las tres regresiones se detectan de verdad: variable nueva en
`config.js`, clave nueva sin comentario y clave nueva en bloque propio.

## Evidencia

- `npm run lint` limpio; `npm test` **444/453** (9 saltados, esperado).
- El generador ejecutado de verdad: emite las cuatro claves vacías y la ayuda sale
  por stderr, fuera del bloque que se copia.
- No toca `infra/prod/` ni ningún fichero de secretos.

Actualiza de paso los recuentos de pruebas de `desarrollo.md`, que se habían
quedado en 388/154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VecRHroNGc9YmtDQDtHRb