### PR TITLE
Producción puede configurar la API de informes, y su árbol vuelve a ser mantenible

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -198,8 +198,11 @@ git show origin/main:infra/prod/compose.yml | grep 'image: ghcr'
 
 Un control que nunca has visto fallar no sabes si existe.
 
-**a) Una PR hacia `test` que toque `infra/prod/`.** La rechaza el job
-«Frontera entre entornos». Producción no se edita trabajando.
+**a) Una PR hacia `test` que mueva la versión desplegada en producción.** La
+rechaza el job «Frontera entre entornos»: las tres etiquetas `image:` y el ancla
+`WORKER_ENV_ACTIVATION` de `infra/prod/compose.yml` sólo las escribe la
+promoción. El resto de `infra/prod/` —variables, límites, plantilla— sí se
+mantiene por PR a `test`, y llega a producción con la siguiente promoción.
 
 **b) Promocionar un commit que no pasó por `test`.** El workflow comprueba que
 existe `:sha-<commit>` en GHCR y que su firma es la de `cd-test.yml`. Falla en
@@ -222,7 +225,7 @@ despliegue no llega a escribir el Compose.
 | `falta DB_APP_PASSWORD` al interpolar | El `.env` del stack no tiene los secretos nuevos | Añadirlos; ver prerrequisitos |
 | `infra/test/compose.yml no apunta a una imagen sha-* válida` | `cd-test.yml` no ha corrido todavía sobre esa rama | Mergear algo a `test`, o lanzarlo a mano |
 | `No existe ghcr.io/…:sha-…` | Se intenta promocionar algo que no pasó por `test` | Empujar a `test`, esperar el build y promocionar después |
-| `Esta PR cambia infra/prod/` | La PR toca producción | Sacar el cambio: producción se mueve promocionando |
+| `Esta PR mueve la versión desplegada en producción` | La PR cambia una etiqueta `image:` o el ancla del worker en `infra/prod/compose.yml` | Sacar esas líneas: la versión sólo la mueve la promoción. Un cambio de configuración de prod sí puede ir en la PR |
 | `El tag vX.Y.Z ya existe y apunta a otro commit` | Se promocionó antes esa versión desde otro commit | Elegir el siguiente salto |
 | `main se movió durante el push` | Otro push aterrizó a la vez | Se reintenta 3 veces solo |
 | El workflow no arranca al empujar | El cambio sólo toca `docs/**` o `*.md` | Lanzarlo con *Run workflow* |

--- a/.github/README.md
+++ b/.github/README.md
@@ -200,9 +200,10 @@ Un control que nunca has visto fallar no sabes si existe.
 
 **a) Una PR hacia `test` que mueva la versión desplegada en producción.** La
 rechaza el job «Frontera entre entornos»: las tres etiquetas `image:` y el ancla
-`WORKER_ENV_ACTIVATION` de `infra/prod/compose.yml` sólo las escribe la
-promoción. El resto de `infra/prod/` —variables, límites, plantilla— sí se
-mantiene por PR a `test`, y llega a producción con la siguiente promoción.
+`WORKER_ENV_ACTIVATION` de `infra/prod/compose.yml` tienen que declarar lo mismo
+que `main`, que es lo que corre de verdad. El resto de `infra/prod/` —variables,
+límites, plantilla— sí se mantiene por PR a `test`, y llega a producción con la
+siguiente promoción.
 
 **b) Promocionar un commit que no pasó por `test`.** El workflow comprueba que
 existe `:sha-<commit>` en GHCR y que su firma es la de `cd-test.yml`. Falla en
@@ -225,7 +226,7 @@ despliegue no llega a escribir el Compose.
 | `falta DB_APP_PASSWORD` al interpolar | El `.env` del stack no tiene los secretos nuevos | Añadirlos; ver prerrequisitos |
 | `infra/test/compose.yml no apunta a una imagen sha-* válida` | `cd-test.yml` no ha corrido todavía sobre esa rama | Mergear algo a `test`, o lanzarlo a mano |
 | `No existe ghcr.io/…:sha-…` | Se intenta promocionar algo que no pasó por `test` | Empujar a `test`, esperar el build y promocionar después |
-| `Esta PR mueve la versión desplegada en producción` | La PR cambia una etiqueta `image:` o el ancla del worker en `infra/prod/compose.yml` | Sacar esas líneas: la versión sólo la mueve la promoción. Un cambio de configuración de prod sí puede ir en la PR |
+| `El Compose de producción de esta PR no declara la versión desplegada` | Las etiquetas `image:` de `infra/prod/compose.yml` no coinciden con las de `main` | Si te las has inventado, quítalas. Si sólo se han quedado atrás tras una promoción, sincronízalas: `git checkout origin/main -- infra/prod/compose.yml` y repite tus cambios |
 | `El tag vX.Y.Z ya existe y apunta a otro commit` | Se promocionó antes esa versión desde otro commit | Elegir el siguiente salto |
 | `main se movió durante el push` | Otro push aterrizó a la vez | Se reintenta 3 veces solo |
 | El workflow no arranca al empujar | El cambio sólo toca `docs/**` o `*.md` | Lanzarlo con *Run workflow* |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           BASE: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "$BASE"
+          git fetch --no-tags origin "$BASE" main
 
           tocados=$(git diff --name-only "origin/${BASE}...HEAD" -- infra/prod/)
           if [ -z "$tocados" ]; then
@@ -56,20 +56,36 @@ jobs:
           fi
           echo "Esta PR toca infra/prod/:"; echo "$tocados"
 
+          if ! echo "$tocados" | grep -qx 'infra/prod/compose.yml'; then
+            echo "No toca el Compose de producción: adelante."
+            exit 0
+          fi
+
           # Las tres etiquetas de imagen y el ancla de entorno del worker son lo
-          # que `cd-promote.yml` reescribe con sed al desplegar. Cambiarlas desde
-          # aquí es desplegar producción por la puerta de atrás, sin tag, sin
-          # firma verificada y sin haber ensayado el digest en test.
-          prohibido=$(git diff "origin/${BASE}...HEAD" -- infra/prod/compose.yml \
-            | grep -E '^[+-] *(image: ghcr\.io/|environment: \*[a-z-]+ # WORKER_ENV_ACTIVATION)' || true)
-          if [ -n "$prohibido" ]; then
-            echo "::error::Esta PR mueve la versión desplegada en producción:"
-            echo "$prohibido"
-            echo "Esas líneas sólo las escribe «[MANUAL] Promocionar a producción»,"
-            echo "que re-etiqueta el digest ya ensayado en test (ADR-028)."
+          # que `cd-promote.yml` reescribe al desplegar, y por tanto lo único de
+          # este árbol que una PR no puede decidir.
+          #
+          # La condición NO es «no las toques» sino «que digan lo que corre de
+          # verdad en producción», es decir, lo mismo que `main`. Prohibir el
+          # cambio a secas dejaba sin arreglo un fichero que se hubiera quedado
+          # atrás —y se quedó: estuvo en v1.0.5 con producción en v1.0.8—, que es
+          # justo el estado que hace que alguien lea una versión equivocada.
+          # Comparar contra `main` cierra las dos puertas a la vez: no se puede
+          # inventar una versión, y no se puede dejar el fichero mintiendo.
+          patron='^ *(image: ghcr\.io/|environment: \*[a-z-]+ # WORKER_ENV_ACTIVATION)'
+          git show "origin/main:infra/prod/compose.yml" | grep -E "$patron" > /tmp/prod-main.txt
+          git show 'HEAD:infra/prod/compose.yml'        | grep -E "$patron" > /tmp/prod-pr.txt
+
+          if ! diff -u --label 'lo que corre en producción (main)' /tmp/prod-main.txt \
+                        --label 'lo que declara esta PR'          /tmp/prod-pr.txt; then
+            echo "::error::El Compose de producción de esta PR no declara la versión desplegada."
+            echo "Esas líneas sólo las escribe «[MANUAL] Promocionar a producción», que"
+            echo "re-etiqueta el digest ya ensayado en test (ADR-028). Copia las de main:"
+            echo "  git checkout origin/main -- infra/prod/compose.yml   # y repite tus cambios"
+            echo "o, si sólo se han quedado atrás tras una promoción, sincronízalas y ya está."
             exit 1
           fi
-          echo "Cambios de configuración, sin mover la versión desplegada: adelante."
+          echo "Declara la versión que corre en producción: adelante."
 
   verify:
     name: Lint, tests e infraestructura

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: infra/prod sólo cambia al promocionar
+      # Lo que hay que proteger es que NADIE MUEVA LA VERSIÓN DESPLEGADA salvo la
+      # promoción (ADR-028), no que `infra/prod/` sea intocable. La regla ancha
+      # —«ninguna PR hacia test toca infra/prod/»— dejaba ese árbol sin ningún
+      # camino de mantenimiento: el Compose de producción se quedó sin
+      # REPORTS_API_TOKEN y su plantilla envejeció, porque la única vía que el
+      # mensaje de error proponía —«va en la PR de promoción»— no existe desde
+      # que `cd-promote.yml` mergea solo, sin PR.
+      #
+      # Así que se protege exactamente la línea que la promoción escribe, y el
+      # resto del árbol de producción viaja por el carril normal: PR a `test`,
+      # CI, y a producción con la siguiente promoción y su número de versión.
+      - name: infra/prod no mueve la versión desplegada
         env:
           BASE: ${{ github.base_ref }}
         run: |
           set -euo pipefail
           git fetch --no-tags origin "$BASE"
+
           tocados=$(git diff --name-only "origin/${BASE}...HEAD" -- infra/prod/)
-          if [ -n "$tocados" ]; then
-            echo "::error::Esta PR cambia infra/prod/, y hacia \`test\` eso no se permite:"
-            echo "$tocados"
-            echo "Producción sólo se mueve promocionando (tag vX.Y.Z sobre \`test\`)."
-            echo "Si el cambio es del Compose de producción, va en la PR de promoción."
+          if [ -z "$tocados" ]; then
+            echo "Sin cambios en infra/prod/."
+            exit 0
+          fi
+          echo "Esta PR toca infra/prod/:"; echo "$tocados"
+
+          # Las tres etiquetas de imagen y el ancla de entorno del worker son lo
+          # que `cd-promote.yml` reescribe con sed al desplegar. Cambiarlas desde
+          # aquí es desplegar producción por la puerta de atrás, sin tag, sin
+          # firma verificada y sin haber ensayado el digest en test.
+          prohibido=$(git diff "origin/${BASE}...HEAD" -- infra/prod/compose.yml \
+            | grep -E '^[+-] *(image: ghcr\.io/|environment: \*[a-z-]+ # WORKER_ENV_ACTIVATION)' || true)
+          if [ -n "$prohibido" ]; then
+            echo "::error::Esta PR mueve la versión desplegada en producción:"
+            echo "$prohibido"
+            echo "Esas líneas sólo las escribe «[MANUAL] Promocionar a producción»,"
+            echo "que re-etiqueta el digest ya ensayado en test (ADR-028)."
             exit 1
           fi
-          echo "Sin cambios en infra/prod/."
+          echo "Cambios de configuración, sin mover la versión desplegada: adelante."
 
   verify:
     name: Lint, tests e infraestructura

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,17 @@ jobs:
           # necesita, y son de baja entropía, no secretos reales. (Los compose.yml
           # son YAML y no pasan por este parser; su saneado se documenta en
           # docs/auditoria-seguridad.md.)
+          #
+          # `infra/local/.env.example` es el tercer caso de la misma familia que
+          # los `.env.ci`: el entorno local trae las dos APIs encendidas y los
+          # secretos puestos a propósito, que es lo que permite levantarlo y
+          # probarlo sin configurar nada. Ahí la regla no puede ser «vacío» —eso
+          # rompería el arranque en local—, pero tampoco «lo que sea», que es
+          # como se cuela un token real. Se exige que el valor SE DECLARE de
+          # desarrollo: sólo minúsculas, dígitos y guiones, y con `local`
+          # dentro. Un secreto de verdad —`openssl rand -hex 32`, un bearer de
+          # Moodle, una contraseña con mayúsculas o símbolos— no cumple ninguna
+          # de las dos cosas y sigue fallando aquí.
           for f in $(git ls-files 'infra/*/.env' 'infra/*/.env.sample' 'infra/*/.env.example'); do
             [ -f "$f" ] || continue
             while IFS= read -r line; do
@@ -173,10 +184,18 @@ jobs:
               key=${line%%=*}; value=${line#*=}
               case "$key" in
                 *SECRET*|*PASSWORD*|*TOKEN*|*AUTHKEY*)
-                  if [ -n "$value" ]; then
+                  [ -n "$value" ] || continue
+                  if [ "$f" = 'infra/local/.env.example' ] &&
+                     printf '%s' "$value" | grep -qE '^[a-z0-9-]+$' &&
+                     printf '%s' "$value" | grep -q 'local'; then
+                    continue
+                  fi
+                  if [ "$f" = 'infra/local/.env.example' ]; then
+                    echo "::error file=$f::$key no se declara de desarrollo (minúsculas, dígitos y guiones, con «local» dentro). Si es un secreto real, sácalo de aquí"
+                  else
                     echo "::error file=$f::$key tiene valor en un fichero versionado"
-                    fail=1
-                  fi ;;
+                  fi
+                  fail=1 ;;
               esac
             done < "$f"
           done

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,19 @@ ENV NODE_ENV=production \
     NPM_CONFIG_UPDATE_NOTIFIER=false
 
 WORKDIR /app
-RUN apk add --no-cache su-exec
+# `node:22-alpine` se reconstruye más despacio de lo que Alpine publica
+# parches, así que al construir arrastra paquetes del sistema con CVE altas ya
+# corregidas aguas arriba. No es hipotético: CVE-2026-14456 (openssl, DoS por
+# crecimiento de memoria sin cota) tumbó el CD con libcrypto3/libssl3 3.5.7-r0
+# mientras el digest fijado arriba YA era el último `22-alpine` publicado —
+# subirlo no arreglaba nada porque el parche vive en el repositorio de Alpine,
+# no en la imagen de Node.
+#
+# Mismo trato que en Dockerfile.proxy, y el mismo precio: esta capa es la única
+# no reproducible de la imagen. Se acepta a propósito. La alternativa —excluir
+# la ruta del análisis— dejaría el binario vulnerable dentro y el gate en verde,
+# que es exactamente al revés de lo que el gate existe para hacer.
+RUN apk upgrade --no-cache && apk add --no-cache su-exec
 
 # npm no pinta nada en runtime: la app arranca con `node src/server.js`, el
 # worker con `node src/worker.js` y el entrypoint no lo llama. Pero sus

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,13 @@ ENV NODE_ENV=production \
     NPM_CONFIG_UPDATE_NOTIFIER=false
 
 WORKDIR /app
+# Antes del upgrade a propósito, y no por orden estético: la caché `gha`
+# (mode=max) sólo invalida una capa cuando cambia algo por encima, así que un
+# `apk upgrade` sin nada variable delante queda congelado y sirve los paquetes
+# del día en que se construyó. Es exactamente lo que le pasó al proxy con
+# CVE-2026-14456. El CI pasa aquí el sha del commit, de modo que los parches se
+# aplican de verdad en cada build. Ver la nota larga en Dockerfile.proxy.
+ARG APP_VERSION=dev
 # `node:22-alpine` se reconstruye más despacio de lo que Alpine publica
 # parches, así que al construir arrastra paquetes del sistema con CVE altas ya
 # corregidas aguas arriba. No es hipotético: CVE-2026-14456 (openssl, DoS por

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -19,16 +19,29 @@
 # que es el módulo del que depende la firma de segmento.
 FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 
+# Lo pasa el bake para las tres imágenes: sirve para que la etiqueta de versión
+# de la imagen coincida con la de app y worker, y —igual de importante— para
+# invalidar el `apk upgrade` de abajo.
+#
+# SU POSICIÓN ES DELIBERADA: tiene que ir ANTES del upgrade. Estaba después, y
+# como la caché `gha` (mode=max) sólo invalida una capa cuando cambia algo por
+# encima, el upgrade quedó congelado: servía los paquetes del día en que se
+# construyó esa capa por primera vez. Se vio con CVE-2026-14456 — el gate de
+# Trivy tumbó un proxy con openssl 3.5.7-r0 mientras Alpine ya publicaba
+# 3.5.8-r0 y este mismo `apk upgrade`, ejecutado de nuevo, lo recogía. Una capa
+# de parches de seguridad servida desde caché es peor que no tenerla: da el
+# verde sin aplicar nada.
+#
+# Como el CI pasa el sha del commit, esto se reconstruye en cada build. Cuesta
+# unos segundos; el valor es que el upgrade se aplica de verdad, siempre.
+ARG APP_VERSION=dev
+
 # La imagen oficial se reconstruye más despacio de lo que Alpine publica
 # parches, así que al construir arrastra paquetes con CVE altas ya
 # corregidas aguas arriba (openssl, curl, expat, libxml2, nghttp2…). Este
 # upgrade las recoge. Es la única capa no reproducible de las tres
 # imágenes, y se acepta a propósito: es un proxy que termina TLS.
 RUN apk upgrade --no-cache
-
-# Lo pasa el bake para las tres imágenes; aquí sólo sirve para que la etiqueta
-# de versión de la imagen coincida con la de app y worker.
-ARG APP_VERSION=dev
 
 COPY infra/nginx/templates/ /etc/nginx/templates/
 COPY infra/nginx/proxy_headers.conf /etc/nginx/proxy_headers.conf

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -1102,13 +1102,18 @@ explicara.
 
 La regla pasa a comprobar **lo que la promoción escribe de verdad**: las tres
 etiquetas `image:` y el ancla `WORKER_ENV_ACTIVATION` de
-`infra/prod/compose.yml`. Mover esas líneas desde una PR de trabajo es desplegar
-producción por la puerta de atrás —sin tag, sin firma verificada y sin haber
-ensayado el digest en test— y se sigue rechazando. El resto del árbol de
-producción —variables, límites, plantilla, README— viaja por el carril normal:
-PR a `test`, CI, y llega a producción con la siguiente promoción y su número de
-versión. Es más trazable que antes, no menos: el cambio se revisa y se ensaya
-en vez de aplicarse a mano sobre `main`.
+`infra/prod/compose.yml`. Y la condición no es «no las toques» sino **que digan
+lo que corre de verdad en producción**: se comparan con las de `main`, y la PR
+pasa si coinciden. Prohibir el cambio a secas —que fue el primer intento— deja
+sin arreglo un fichero que se haya quedado atrás, y quedarse atrás es
+precisamente lo que hace que alguien lea una versión equivocada. Comparar contra
+`main` cierra las dos puertas de una vez: no se puede inventar una versión desde
+una PR, y no se puede dejar el fichero mintiendo.
+
+El resto del árbol de producción —variables, límites, plantilla, README— viaja
+por el carril normal: PR a `test`, CI, y llega a producción con la siguiente
+promoción y su número de versión. Es más trazable que antes, no menos: el cambio
+se revisa y se ensaya en vez de aplicarse a mano sobre `main`.
 
 El punto ciego que lo permitió también se cierra: `test/env-example.test.js`
 estaba exento de mirar `infra/prod/` precisamente porque no se podía tocar, y
@@ -1116,10 +1121,13 @@ ahora exige a su plantilla lo mismo que a las otras dos —documentar cada
 variable configurable, y ninguna de más—, con una prueba extra que comprueba que
 las dos APIs se pueden configurar en **los tres** entornos.
 
-Las etiquetas de imagen quedan, eso sí, una versión por detrás en `test` entre
-promoción y promoción: nadie despliega producción desde ahí, y el merge de la
-promoción conserva las de `main` porque `test` no las toca. Está escrito en la
-cabecera del propio Compose para que el fichero no vuelva a mentir en silencio.
+Las etiquetas de imagen quedan, eso sí, una versión por detrás en `test` desde
+cada promoción hasta la siguiente PR que toque ese Compose: nadie despliega
+producción desde ahí, y el merge de la promoción conserva las de `main` porque
+`test` no las toca. La comprobación sólo se exige a la PR que edita el fichero
+—que es justo cuando sincronizarlo cuesta un `git checkout`—, no a las demás.
+Está escrito además en la cabecera del propio Compose, para que el fichero no
+vuelva a mentir en silencio.
 
 **Cómo revertirlo.** Devolver los dos stacks de Portainer a `refs/heads/main`,
 volver a disparar `cd-test.yml` con `branches: [main]` y quitar el job

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -1076,8 +1076,8 @@ riesgo que era.
 Dos cierres más, porque una convención que sólo vive en la cabeza de alguien no
 es un control:
 
-- El job `frontera-entornos` de `ci.yml` rechaza toda PR hacia `test` que toque
-  `infra/prod/`. Producción no se edita trabajando.
+- El job `frontera-entornos` de `ci.yml` rechaza toda PR hacia `test` que mueva
+  la versión desplegada en producción. Producción no se despliega trabajando.
 - `cd-promote.yml` falla en cerrado si no existe el `:sha-<commit>` del commit
   etiquetado: no se promociona nada que no haya pasado por test.
 
@@ -1089,6 +1089,37 @@ versión, verifica la firma, etiqueta, re-etiqueta el digest y mueve `main`.
 Empujar un tag a mano ya no promociona nada. Todos los workflows llevan además
 `[AUTO]` o `[MANUAL]` en el nombre —el prefijo dice si hay que hacer algo— y el
 manual del pipeline vive en [`.github/README.md`](../.github/README.md).
+
+**Actualización (27 de agosto de 2026): la frontera protege la versión, no el
+directorio.** `frontera-entornos` rechazaba toda PR hacia `test` que tocara
+`infra/prod/`, y el mensaje de error remitía a «la PR de promoción» — que dejó de
+existir con la actualización de arriba, cuando `cd-promote.yml` pasó a mergear
+solo. El resultado fue un árbol sin ningún camino de mantenimiento: el Compose de
+producción se quedó sin `REPORTS_API_TOKEN` mientras test sí lo tenía, y su
+plantilla documentaba 31 de 82 variables. La API de informes habría llegado a
+producción respondiendo 404, con el token puesto en Portainer y nada que lo
+explicara.
+
+La regla pasa a comprobar **lo que la promoción escribe de verdad**: las tres
+etiquetas `image:` y el ancla `WORKER_ENV_ACTIVATION` de
+`infra/prod/compose.yml`. Mover esas líneas desde una PR de trabajo es desplegar
+producción por la puerta de atrás —sin tag, sin firma verificada y sin haber
+ensayado el digest en test— y se sigue rechazando. El resto del árbol de
+producción —variables, límites, plantilla, README— viaja por el carril normal:
+PR a `test`, CI, y llega a producción con la siguiente promoción y su número de
+versión. Es más trazable que antes, no menos: el cambio se revisa y se ensaya
+en vez de aplicarse a mano sobre `main`.
+
+El punto ciego que lo permitió también se cierra: `test/env-example.test.js`
+estaba exento de mirar `infra/prod/` precisamente porque no se podía tocar, y
+ahora exige a su plantilla lo mismo que a las otras dos —documentar cada
+variable configurable, y ninguna de más—, con una prueba extra que comprueba que
+las dos APIs se pueden configurar en **los tres** entornos.
+
+Las etiquetas de imagen quedan, eso sí, una versión por detrás en `test` entre
+promoción y promoción: nadie despliega producción desde ahí, y el merge de la
+promoción conserva las de `main` porque `test` no las toca. Está escrito en la
+cabecera del propio Compose para que el fichero no vuelva a mentir en silencio.
 
 **Cómo revertirlo.** Devolver los dos stacks de Portainer a `refs/heads/main`,
 volver a disparar `cd-test.yml` con `branches: [main]` y quitar el job

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -446,8 +446,11 @@ son automáticos: no los edites ni los borres a mano, son lo que activa GitOps.
 
 Sólo se promociona un commit que ya esté desplegado en test: si no existe su
 `:sha-<commit>` en GHCR, o su firma no es la de `cd-test.yml`, la promoción falla
-en cerrado. Y una PR hacia `test` que toque `infra/prod/` la rechaza el job
-«Frontera entre entornos» de `ci.yml`. Empujar un tag a mano no promociona nada.
+en cerrado. Y una PR hacia `test` que mueva la versión desplegada en producción
+—las etiquetas `image:` o el ancla del worker de `infra/prod/compose.yml`— la
+rechaza el job «Frontera entre entornos» de `ci.yml`; el resto de la
+configuración de prod sí se mantiene por ese carril. Empujar un tag a mano no
+promociona nada.
 
 **Todo el pipeline —qué hace cada workflow, cómo se promociona paso a paso, qué
 comprobar y qué errores significan qué— está en

--- a/infra/README.md
+++ b/infra/README.md
@@ -225,7 +225,7 @@ sobra una que ya nadie lee, o si alguna se queda sin comentario.
 |---|---|---|
 | local | [`local/.env.example`](local/.env.example) | Todo lo configurable del stack de desarrollo, con sus valores por defecto y los tokens de las dos APIs, que en local vienen encendidas |
 | test | [`test/.env.sample`](test/.env.sample) | Referencia de las 84 variables del stack, con cuáles son obligatorias y cuáles no se pueden rotar nunca |
-| prod | [`prod/.env.sample`](prod/.env.sample) | Lo mismo para producción. Sólo se actualiza en la PR de promoción: hacia `test` no se puede tocar `infra/prod/` (ADR-028) |
+| prod | [`prod/.env.sample`](prod/.env.sample) | Lo mismo para producción. Se mantiene por PR a `test` como las otras dos, y llega a prod con la siguiente promoción; lo único que no se puede tocar desde una PR son las etiquetas de imagen (ADR-028) |
 
 Y la de la aplicación, por debajo del Compose, en
 [`.env.example`](../.env.example) de la raíz.

--- a/infra/prod/.env.sample
+++ b/infra/prod/.env.sample
@@ -1,17 +1,69 @@
-# Plantilla del bloque de variables del stack.
+# =============================================================================
+# MoodleShield · PRODUCCIÓN — referencia de TODAS las variables del stack
 #
-# Genera el bloque real (con secretos ya generados) con:
+# Este fichero es la lista completa de lo que lee `compose.yml` de esta carpeta,
+# con su valor por defecto y qué hace cada una. Nunca lleva secretos: se versiona
+# en un repositorio público, sirve de referencia y valida el Compose en CI.
+#
+# El bloque REAL, con secretos ya generados, sale de:
 #   ./scripts/generate-env.sh prod
-# y pégalo en Portainer → Stack → Environment variables → Advanced mode.
+# y se pega en Portainer → Stack → Environment variables → Advanced mode.
 #
-# Este fichero versionado nunca lleva secretos: sólo sirve de referencia y para
-# validar el compose en CI.
+# ⚠️ En ese bloque NO va ni una línea de comentario: Portainer no interpreta un
+# fichero .env, mantiene una lista de pares, y un `# nota` acaba convertido en
+# una variable con nombre absurdo. Por eso lo que hay que explicar se explica
+# AQUÍ, y el generador lo repite por stderr.
+#
+# Sólo hacen falta las que el Compose marca con `:?` (abajo van señaladas como
+# OBLIGATORIA). El resto tiene valor por defecto y basta con no ponerlas.
+#
+# ⚠️ ESTE STACK TIENE MATERIAL REAL DENTRO. Al añadir una variable a un stack ya
+# en marcha, en Portainer se EDITA la lista existente: regenerar el bloque entero
+# con `generate-env.sh` y pegarlo encima acuña secretos NUEVOS y se lleva por
+# delante las trazas forenses, los enlaces firmados y las actividades ya
+# insertadas en Moodle. Ver el bloque de secretos, más abajo.
+# =============================================================================
 
+# --- Ubicación y publicación -------------------------------------------------
+
+# OBLIGATORIA. Raíz absoluta de todo el estado persistente: quedará como
+# $DATA_ROOT/{pgdata,media,uploads}. Prepárala antes del primer despliegue con
+#   sudo ./scripts/bootstrap-host.sh /docker-apps/moodleshield-pro prod
 DATA_ROOT=/docker-apps/moodleshield-pro
+
+# OBLIGATORIA. URL pública tal y como la ve Moodle. Tiene que ser https o Moodle
+# rechaza la herramienta. Es el origen canónico: el que se registra en Moodle y
+# el que se emite en redirect_uri, visor, playlist y consola.
+# ⚠️ Cambiarla en un stack en marcha obliga a reconfigurar la herramienta en
+# Moodle: las actividades ya insertadas apuntan al nombre antiguo.
 PUBLIC_URL=https://moodleshield.example.com
+
+# Otros nombres por los que se alcanza ESTA MISMA instancia, separados por coma.
+# Lista blanca a propósito, porque la cabecera Host la escribe quien llama.
+# Si la instancia ya tenía alguno, VUELVE A PONERLO al regenerar el bloque: sin
+# él la consola responde 403 al iniciar sesión, porque el Origin del formulario
+# no está en la lista.
+PUBLIC_URL_ALIASES=
+
+# 127.0.0.1 porque en producción el nginx del edge corre NATIVO en el host. Si
+# el edge fuese un contenedor, desde ahí 127.0.0.1 es su propio loopback y haría
+# falta 0.0.0.0. En ambos casos el puerto va sin cifrar: filtra quién llega a él.
 HTTP_BIND_ADDRESS=127.0.0.1
 HTTP_PORT=43127
 
+# --- Base de datos -----------------------------------------------------------
+# El propietario (DB_USER) sólo lo usa el bootstrap: el entrypoint aplica las
+# migraciones con él y le quita la contraseña del entorno antes de arrancar la
+# web, que sirve siempre con DB_APP_USER. El worker sólo recibe su propio par.
+# Los tres nombres tienen valor por defecto; las tres contraseñas son
+# OBLIGATORIAS y las genera `generate-env.sh`.
+#
+# A diferencia de test, aquí Postgres NO se publica en el host: no hay
+# DB_BIND_ADDRESS ni DB_PORT_HOST. Se entra por `docker exec`.
+#
+# Nota: DB_PROVISION_SERVICE_ROLES está fijado a "true" dentro del Compose y no
+# se puede cambiar desde aquí. Es lo que crea y ajusta los roles moodleshield_app
+# y moodleshield_worker al aplicar las migraciones.
 DB_NAME=moodleshield
 DB_USER=moodleshield
 DB_PASSWORD=
@@ -19,36 +71,222 @@ DB_APP_USER=moodleshield_app
 DB_APP_PASSWORD=
 DB_WORKER_USER=moodleshield_worker
 DB_WORKER_PASSWORD=
+
+# --- Secretos (OBLIGATORIOS los cuatro, mínimo 32 caracteres) ----------------
+# Genéralos con `openssl rand -hex 32`, o deja que lo haga generate-env.sh.
+#
+# ⚠️ NINGUNO DE LOS CUATRO SE PUEDE ROTAR en este stack, que lleva material real
+# y actividades vivas dentro:
+#   SESSION_SECRET     firma las sesiones Y la referencia del material que
+#                      Moodle lleva incrustada en cada actividad (T24,
+#                      custom.resourcesig). Rotarlo rompe TODA actividad ya
+#                      insertada, no sólo las sesiones abiertas.
+#   WATERMARK_SECRET   deriva el patrón A/B de cada alumno. Rotarlo deja sin
+#                      atribuir cualquier filtración anterior.
+#   MEDIA_KEY_SECRET   deriva las claves de cifrado de los segmentos HLS.
+#                      Rotarlo deja ilegible el material ya publicado.
+#   MEDIA_LINK_SECRET  firma los enlaces que valida nginx (secure_link). Lo
+#                      comparten app y proxy: si difieren, todos los segmentos
+#                      devuelven 403.
 SESSION_SECRET=
 WATERMARK_SECRET=
 MEDIA_KEY_SECRET=
 MEDIA_LINK_SECRET=
-CONTENT_API_TOKEN=
-CONTENT_API_ALLOWED_PLATFORM_IDS=
+
+# Token para dar de alta plataformas por API (POST /lti/platforms). Vacío
+# desactiva ese endpoint. Si lo rellenas, mínimo 32 caracteres.
 LTI_ADMIN_TOKEN=
-# Vacío desactiva la API de plataformas. Si lo rellenas, mínimo 32 caracteres.
 
-# T24: verificación de la referencia firmada del material en cada launch.
-# En producción la app sólo arranca con `enforce`; se declara aquí para que el
-# valor sea visible y nadie lo baje a `warn` sin darse cuenta.
-LAUNCH_RESOURCE_SIGNATURE=enforce
+# --- APIs de integración (/api/v1) -------------------------------------------
+# Dos APIs bajo el mismo prefijo, con tokens DISTINTOS y no intercambiables: la
+# aplicación NO ARRANCA si coinciden. Con su token vacío, cada una responde 404
+# en todas sus rutas: una API deshabilitada no se anuncia. El contrato se sirve
+# en /api/v1/openapi.json, recortado a las que estén activas, con lector en
+# /api/v1/docs.
+#
+# ⚠️ Poner un token SIN su lista de plataformas ABORTA EL ARRANQUE. Van las dos,
+# o ninguna. Y el token, mínimo 32 caracteres.
+# El UUID de cada instancia está en la consola, en la URL de su botón «Editar».
 
-# Nota: DB_PROVISION_SERVICE_ROLES está fijado a "true" dentro del compose y no
-# se puede cambiar desde aquí. Es lo que crea y ajusta los roles moodleshield_app
-# y moodleshield_worker al aplicar las migraciones.
+# API de CONTENIDO — escritura. Sube material eligiendo `owner_sub`, es decir
+# SUPLANTANDO A CUALQUIER PROFESOR. Déjala apagada fuera de una migración y rota
+# el token al terminar.
+CONTENT_API_TOKEN=
+# UUID separados por coma. Una petición que declare otra plataforma recibe 403
+# aunque el bearer sea correcto.
+CONTENT_API_ALLOWED_PLATFORM_IDS=
 
+# API de INFORMES — sólo lectura (ADR-030). Es la de avances de alumnos, la que
+# se cruza con una herramienta externa de seguimiento. Devuelve nombre y username
+# de Moodle —son la clave del cruce— pero jamás `ip` ni `user_agent`, que son del
+# registro forense. Quien sólo consulta avances no debe sostener el token de
+# contenido.
+REPORTS_API_TOKEN=
+# Mismas reglas que la lista de contenido.
+REPORTS_API_ALLOWED_PLATFORM_IDS=
+
+# --- Consola web de administración (/admin) ----------------------------------
+# Las tres primeras son OBLIGATORIAS: el Compose las exige con `:?`, que también
+# rechaza el valor vacío. Genera el hash sin exponer la contraseña:
+#   node scripts/hash-admin-password.mjs
 ADMIN_USERNAME=
 ADMIN_PASSWORD_HASH=
 ADMIN_SESSION_SECRET=
+# 28800 = 8 horas.
 ADMIN_SESSION_TTL_SECONDS=28800
+# Permite dar de alta un Moodle en una IP privada. Sólo para Moodles internos
+# controlados: amplía la superficie SSRF. En producción, `false`.
 ADMIN_ALLOW_PRIVATE_LTI_HOSTS=false
 
-LOG_LEVEL=info
-MARK_ALPHA=0.06
-WORKER_CPUS=2
-WORKER_MEMORY=1536m
+# --- LTI ---------------------------------------------------------------------
+# Parámetro personalizado de Moodle con el identificador visible del alumno; es
+# la clave con la que la API de informes cruza con una herramienta externa.
+# Moodle no manda el username en ningún claim estándar de LTI 1.3: se configura
+# en la herramienta como  username=$User.username
+LTI_IDENTITY_CUSTOM_PARAM=username
+# Lo que se le enseña al administrador de Moodle para que lo copie. Las comillas
+# simples son de este fichero, no del valor: impiden que Docker Compose expanda
+# `$User` al validar y lo deje en `.username`. En el bloque de Portainer, que no
+# es un .env, va sin comillas.
+LTI_IDENTITY_MOODLE_SOURCE='$User.username'
+
+# T24: verificación de la referencia firmada del material en cada launch.
+# En producción la app SÓLO ARRANCA con `enforce`; se declara aquí para que el
+# valor sea visible y nadie lo baje a `warn` sin darse cuenta.
+# ⚠️ Toda actividad insertada ANTES de la migración 014 hay que reinsertarla:
+# no lleva custom.resourcesig y con `enforce` deja de abrirse.
+LAUNCH_RESOURCE_SIGNATURE=enforce
+
+# Duración del token de sesión emitido tras un launch LTI. 14400 = 4 horas.
+SESSION_TTL_SECONDS=14400
+
+# --- Red y origen público ----------------------------------------------------
+# Hay exactamente un nginx controlado delante de Node. No amplíes esta confianza.
+TRUST_PROXY=1
+# IP real del alumno cuando delante hay un CDN (ADR-019), y la IP es evidencia:
+#   auto   → CF-Connecting-IP sólo si viene de un rango publicado de Cloudflare
+#   always → confiar siempre; para un túnel cloudflared, donde el borde no
+#            aparece en la cadena de proxies
+#   never  → ignorar la cabecera
+# Con un nginx intermedio que reescriba X-Forwarded-For, la única IP que llega
+# es la del borde y todos los visionados quedan registrados igual.
+TRUST_CLOUDFLARE_CLIENT_IP=auto
+# CIDR extra que cuentan como CDN de confianza, separados por coma.
+CDN_TRUSTED_RANGES=
+
+# --- Entrega de medios -------------------------------------------------------
+# Duración de los enlaces firmados que valida nginx (secure_link). Tiene que
+# cubrir el visionado más largo que esperes. 14400 = 4 horas.
+MEDIA_LINK_TTL_SECONDS=14400
+
+# --- Subidas y cuotas --------------------------------------------------------
+# Tamaño máximo de un material. 4 GiB en producción, el doble que en test.
+MAX_UPLOAD_BYTES=4294967296
+# Tamaño de cada fragmento del protocolo troceado. Cada petición queda por
+# debajo del máximo de 100 MB de Cloudflare Free/Pro, que es lo que obliga a
+# trocear.
+UPLOAD_CHUNK_BYTES=16777216
+# Cuánto sobrevive una subida a medias antes de liberarse. 86400 = 1 día.
+UPLOAD_SESSION_TTL_SECONDS=86400
+# Suelo de disco libre por debajo del cual se rechaza reservar una subida.
+STORAGE_MIN_FREE_BYTES=5368709120
+# Cupos por profesor. -1 = sin límite.
+MAX_ACTIVE_UPLOADS_PER_OWNER=5
+# La cola de procesado va sin tope: encolar no consume disco ni CPU, y ponerle
+# número obliga a importar una carpeta grande en varias pasadas manuales. El
+# disco lo siguen guardando STORAGE_MIN_FREE_BYTES y MAX_STORED_BYTES_PER_OWNER.
+MAX_PENDING_JOBS_PER_OWNER=-1
+MAX_RESERVED_UPLOAD_BYTES_PER_OWNER=8589934592
+MAX_STORED_BYTES_PER_OWNER=107374182400
+# Techos de nginx, en su propia sintaxis.
 MAX_UPLOAD_SIZE=4g
 # Techo de cada fragmento del protocolo troceado; mayor que UPLOAD_CHUNK_BYTES
 # (16 MiB por defecto) o cada PUT respondería 413.
 MAX_CHUNK_SIZE=32m
-MAX_UPLOAD_BYTES=4294967296
+
+# --- Reproducción ------------------------------------------------------------
+# IP distintas toleradas para un mismo permiso de reproducción antes de marcarlo
+# como sospechoso. Un alumno que cambia de wifi a datos ya usa dos.
+PLAYBACK_MAX_DISTINCT_IPS=3
+# Si al superarlo se revoca el permiso además de registrarlo.
+PLAYBACK_REVOKE_ON_SUSPICION=true
+
+# --- Transcodificación (vídeo) -----------------------------------------------
+# ⚠️ SEGMENT_SECONDS fija los cortes que hacen intercambiables las variantes A y
+# B. Cambiarlo NO reprocesa lo ya publicado: el material antiguo conserva sus
+# cortes y sigue funcionando, pero deja de compartir tamaño de segmento con el
+# nuevo. No se toca sin motivo.
+SEGMENT_SECONDS=4
+OUTPUT_FPS=24
+OUTPUT_CRF=21
+OUTPUT_PRESET=veryfast
+# Opacidad de la marca A/B. 0.04–0.08 es imperceptible, que es lo que quiere
+# producción: la marca tiene que estar sin verse. En test se sube a 0.5 a
+# propósito, para poder VER el patrón.
+MARK_ALPHA=0.06
+# Se valida al arrancar: cada worker procesa exactamente un fichero a la vez.
+TRANSCODE_CONCURRENCY=1
+# Cuánto puede un worker retener un trabajo sin dar señales, y cada cuánto la da.
+# El heartbeat debe ser sensiblemente menor que el lease.
+TRANSCODE_LEASE_SECONDS=90
+TRANSCODE_HEARTBEAT_MS=20000
+# Cortan ffprobe/ffmpeg si un fichero hostil los deja colgados. 21600 = 6 horas.
+TRANSCODE_PROBE_TIMEOUT_SECONDS=30
+TRANSCODE_PROCESS_TIMEOUT_SECONDS=21600
+# Prioridad de ffmpeg. Es lo que deja el host respondiendo mientras transcodifica.
+FFMPEG_NICE=10
+# Cota VBV por variante; permite reservar disco y cuota antes de ejecutar ffmpeg.
+VIDEO_MAX_OUTPUT_BITRATE_KBPS=8000
+# Recorta el lado largo de la salida. 0 = sin recorte, y es lo que producción ha
+# hecho siempre: se cablea para poder cambiarlo sin tocar el Compose, no para
+# cambiarlo ahora. 1080 es lo sensato para un reproductor dentro de un iframe:
+# en vídeo vertical de móvil (1440x1920) divide por tres los píxeles, y se
+# codifican DOS veces. Sólo afecta a lo que se suba a partir de entonces.
+VIDEO_MAX_OUTPUT_LONG_SIDE=0
+# Límites de lo que se acepta como fuente. Rechazar aquí es barato; descubrirlo
+# a mitad de un ffmpeg de seis horas, no.
+VIDEO_MAX_DURATION_SECONDS=14400
+VIDEO_MAX_PIXELS=8294400
+VIDEO_MAX_DIMENSION=4096
+VIDEO_MAX_STREAMS=16
+VIDEO_MAX_SOURCE_FPS=120
+VIDEO_MAX_AUDIO_CHANNELS=8
+
+# --- Materiales PDF ----------------------------------------------------------
+# Límite propio: un PDF de 100 MB ya es enorme; un vídeo de 100 MB, corto.
+MAX_PDF_BYTES=104857600
+MAX_PDF_PAGES=500
+# Corta qpdf/Ghostscript/pdftoppm si un fichero hostil los deja colgados.
+PDF_PROCESS_TIMEOUT_SECONDS=180
+
+# --- Biblioteca y revisiones -------------------------------------------------
+MAX_FOLDERS_PER_OWNER=100
+MAX_COLLECTION_ITEMS=50
+# 'auto'   → la revisión se publica en cuanto queda lista
+# 'manual' → espera a que el profesor pulse «Publicar revisión»
+MATERIAL_REVISION_ACTIVATION=auto
+# Una revisión retirada no se purga antes de que caduquen los tokens ya
+# emitidos: se aplica el mayor de SESSION_TTL_SECONDS, MEDIA_LINK_TTL_SECONDS y
+# estos días de retención.
+MATERIAL_REVISION_RETENTION_DAYS=30
+MATERIAL_REVISION_KEEP_MIN=2
+# Archivar NO es borrar: pasados estos días, un material archivado es candidato
+# a purga y su UUID deja de resolver. Súbelo antes de archivar en lote.
+MATERIAL_ARCHIVE_RETENTION_DAYS=90
+
+# --- Límites de tasa (en memoria, por proceso) -------------------------------
+# nginx añade límites de borde; las cuotas de almacenamiento y cola se aplican
+# transaccionalmente en PostgreSQL.
+RATE_LIMIT_PUBLIC_AUTH_15M=120
+RATE_LIMIT_MIGRATION_PER_MINUTE=300
+RATE_LIMIT_CATALOG_PER_MINUTE=600
+RATE_LIMIT_PLAYBACK_PER_MINUTE=1200
+
+# --- Recursos del host y diagnóstico -----------------------------------------
+# 'info' en producción; 'debug' sólo para seguir un launch concreto, y se baja
+# después: el log de debug lleva identificadores de alumno.
+LOG_LEVEL=info
+# ffmpeg necesita margen: WORKER_CPUS son los núcleos que se le ceden. Producción
+# reserva más que test porque aquí sí hay carga real.
+WORKER_CPUS=2
+WORKER_MEMORY=1536m

--- a/infra/prod/compose.yml
+++ b/infra/prod/compose.yml
@@ -12,8 +12,15 @@
 #   - Rutas de volumen absolutas: Portainer no ejecuta el compose desde una
 #     carpeta estable, así que las rutas relativas apuntan a cualquier sitio.
 #   - Los secretos se definen en las variables de entorno del stack en
-#     Portainer, NUNCA en este repositorio. Las referencias de imagen de abajo
-#     son el estado desplegado; el CI actualiza sus tags directamente aquí.
+#     Portainer, NUNCA en este repositorio.
+#   - Las tres etiquetas de imagen las escribe SÓLO la promoción, sobre `main`.
+#     En `main` son, por tanto, la versión que corre ahora mismo en producción.
+#     En `test` pueden ir una versión por detrás entre promoción y promoción, y
+#     es normal: nadie despliega producción desde `test`, y el merge de la
+#     promoción conserva las de `main` porque `test` no las toca. El job
+#     «Frontera entre entornos» rechaza la PR que intente moverlas.
+#     El resto de este fichero —variables, límites— sí se mantiene por el carril
+#     normal: PR a `test`, y llega a producción con la siguiente promoción.
 #   - Todo el estado persistente vive bajo ${DATA_ROOT}: pgdata, media y
 #     uploads. Cambiar de host sólo exige copiar esa raíz y conservar el .env.
 #
@@ -38,6 +45,11 @@ x-runtime-hardening: &runtime-hardening
 
 x-app-env: &app-env
   NODE_ENV: production
+  # Qué stack es éste, en la consola y en el log de arranque. `NODE_ENV` no
+  # sirve para distinguirlos —vale `production` en test y aquí— y ésa es justo
+  # la confusión que costó dos días. Va fijo, no por .env: un stack no puede
+  # mentir sobre cuál es.
+  MOODLESHIELD_ENV: prod
   SERVICE_ROLE: app
   LOG_LEVEL: ${LOG_LEVEL:-info}
   PUBLIC_URL: ${PUBLIC_URL:?falta PUBLIC_URL}
@@ -58,6 +70,11 @@ x-app-env: &app-env
   LTI_ADMIN_TOKEN: ${LTI_ADMIN_TOKEN:-}
   CONTENT_API_TOKEN: ${CONTENT_API_TOKEN:-}
   CONTENT_API_ALLOWED_PLATFORM_IDS: ${CONTENT_API_ALLOWED_PLATFORM_IDS:-}
+  # API de informes: sólo lectura, token PROPIO (ADR-030). Vacía = todas sus
+  # rutas en 404, que es como sale de fábrica. Poner el token SIN su lista de
+  # plataformas aborta el arranque: van las dos, o ninguna.
+  REPORTS_API_TOKEN: ${REPORTS_API_TOKEN:-}
+  REPORTS_API_ALLOWED_PLATFORM_IDS: ${REPORTS_API_ALLOWED_PLATFORM_IDS:-}
   ADMIN_USERNAME: ${ADMIN_USERNAME:?falta ADMIN_USERNAME}
   ADMIN_PASSWORD_HASH: ${ADMIN_PASSWORD_HASH:?falta ADMIN_PASSWORD_HASH}
   ADMIN_SESSION_SECRET: ${ADMIN_SESSION_SECRET:?falta ADMIN_SESSION_SECRET}
@@ -108,6 +125,10 @@ x-app-env: &app-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # Recorta el lado largo de la salida. 0 = sin recorte, que es el
+  # comportamiento que producción lleva teniendo siempre y no se cambia al
+  # cablearla: esto sólo hace que se PUEDA cambiar sin tocar el Compose.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}
@@ -130,6 +151,7 @@ x-app-env: &app-env
 # como administrador aunque se comprometiera ffmpeg/Ghostscript.
 x-worker-env: &worker-env
   NODE_ENV: production
+  MOODLESHIELD_ENV: prod
   SERVICE_ROLE: worker
   LOG_LEVEL: ${LOG_LEVEL:-info}
   DB_HOST: db
@@ -160,6 +182,10 @@ x-worker-env: &worker-env
   TRANSCODE_PROBE_TIMEOUT_SECONDS: ${TRANSCODE_PROBE_TIMEOUT_SECONDS:-30}
   TRANSCODE_PROCESS_TIMEOUT_SECONDS: ${TRANSCODE_PROCESS_TIMEOUT_SECONDS:-21600}
   VIDEO_MAX_OUTPUT_BITRATE_KBPS: ${VIDEO_MAX_OUTPUT_BITRATE_KBPS:-8000}
+  # Recorta el lado largo de la salida. 0 = sin recorte, que es el
+  # comportamiento que producción lleva teniendo siempre y no se cambia al
+  # cablearla: esto sólo hace que se PUEDA cambiar sin tocar el Compose.
+  VIDEO_MAX_OUTPUT_LONG_SIDE: ${VIDEO_MAX_OUTPUT_LONG_SIDE:-0}
   VIDEO_MAX_DURATION_SECONDS: ${VIDEO_MAX_DURATION_SECONDS:-14400}
   VIDEO_MAX_PIXELS: ${VIDEO_MAX_PIXELS:-8294400}
   VIDEO_MAX_DIMENSION: ${VIDEO_MAX_DIMENSION:-4096}
@@ -208,7 +234,7 @@ services:
   # ---------------------------------------------------------------------------
   app:
     <<: *runtime-hardening
-    image: ghcr.io/jamataran/moodleshield/app:v1.0.5
+    image: ghcr.io/jamataran/moodleshield/app:v1.0.8
     restart: unless-stopped
     init: true
     depends_on:
@@ -239,7 +265,7 @@ services:
   # tumbe el servicio web y para poder limitarle CPU de forma independiente.
   worker:
     <<: *runtime-hardening
-    image: ghcr.io/jamataran/moodleshield/worker:v1.0.5
+    image: ghcr.io/jamataran/moodleshield/worker:v1.0.8
     restart: unless-stopped
     init: true
     stop_grace_period: 45s
@@ -252,7 +278,7 @@ services:
         condition: service_healthy
     # Compatibilidad de rollout: v1.0.5 aún exige *app-env. release.yml cambia
     # este anchor en el mismo commit que apunta a la primera imagen compatible.
-    environment: *app-env # WORKER_ENV_ACTIVATION
+    environment: *worker-env # WORKER_ENV_ACTIVATION
     volumes:
       - "${DATA_ROOT:?falta DATA_ROOT}/media:/data/media:z"
       - "${DATA_ROOT:?falta DATA_ROOT}/uploads:/data/uploads:z"
@@ -277,7 +303,7 @@ services:
   # que monta son los medios que sirve con sendfile.
   proxy:
     <<: *runtime-hardening
-    image: ghcr.io/jamataran/moodleshield/proxy:v1.0.5
+    image: ghcr.io/jamataran/moodleshield/proxy:v1.0.8
     restart: unless-stopped
     depends_on:
       app:

--- a/test/env-example.test.js
+++ b/test/env-example.test.js
@@ -114,9 +114,14 @@ test('.env.example avisa de que un token sin su lista aborta el arranque', () =>
  * qué una API responde 404 — pasó con `REPORTS_API_TOKEN`, que estuvo meses en
  * el Compose de test sin aparecer en ninguna plantilla.
  *
- * `infra/prod/` no entra aquí: hacia `test` no se puede tocar (ADR-028, y el job
- * «Frontera entre entornos» lo rechaza), así que su plantilla se pone al día en
- * la PR de promoción y no puede ser condición para mergear a `test`.
+ * `infra/prod/` SÍ entra aquí. Antes no podía: la «Frontera entre entornos»
+ * rechazaba toda PR hacia `test` que tocara ese árbol, así que exigirle una
+ * plantilla al día habría sido pedir algo imposible de cumplir. Esa regla ahora
+ * protege sólo lo que de verdad es de la promoción —las tres etiquetas de imagen
+ * y el ancla de entorno del worker—, y el resto del Compose de producción se
+ * mantiene por el carril normal. El precio de aquella exención fue exacto:
+ * `REPORTS_API_TOKEN` llegó al Compose de test y a su plantilla, y producción se
+ * quedó sin la variable y con una plantilla que documentaba 31 de 82.
  */
 
 /** Las variables que un Compose deja configurar desde el entorno del stack. */
@@ -136,7 +141,8 @@ const RESPALDOS_HEREDADOS = new Set(['BIND_ADDRESS'])
 
 const entornos = [
   { nombre: 'local', compose: 'infra/local/compose.yml', plantilla: 'infra/local/.env.example' },
-  { nombre: 'test', compose: 'infra/test/compose.yml', plantilla: 'infra/test/.env.sample' }
+  { nombre: 'test', compose: 'infra/test/compose.yml', plantilla: 'infra/test/.env.sample' },
+  { nombre: 'prod', compose: 'infra/prod/compose.yml', plantilla: 'infra/prod/.env.sample' }
 ]
 
 const plantillaDeTest = await readFile(path.join(root, 'infra/test/.env.sample'), 'utf8')
@@ -166,6 +172,27 @@ for (const entorno of entornos) {
       `claves de ${entorno.plantilla} sin ningún comentario que las explique`)
   })
 }
+
+test('las dos APIs se pueden configurar en LOS TRES entornos', async () => {
+  // El fallo que motivó esta prueba: `REPORTS_API_TOKEN` se cableó en el Compose
+  // de test y no en el de producción, así que la API de informes habría llegado
+  // a producción respondiendo 404 sin que nada lo dijera — y con el token puesto
+  // en Portainer, porque el operador no tiene forma de saber que el Compose no
+  // lo lee. Una variable que existe en un entorno y no en otro es una promoción
+  // que se descubre rota en producción.
+  for (const entorno of entornos) {
+    const compose = await readFile(path.join(root, entorno.compose), 'utf8')
+    const configurables = variablesDelCompose(compose)
+    for (const nombre of [
+      'CONTENT_API_TOKEN',
+      'CONTENT_API_ALLOWED_PLATFORM_IDS',
+      'REPORTS_API_TOKEN',
+      'REPORTS_API_ALLOWED_PLATFORM_IDS'
+    ]) {
+      assert.ok(configurables.has(nombre), `${entorno.compose} no deja configurar ${nombre}`)
+    }
+  }
+})
 
 test('la plantilla de test avisa de la trampa de las dos APIs', () => {
   // En test NODE_ENV=production: un token sin su lista de plataformas aborta el


### PR DESCRIPTION
Tres bloqueos entre `test` y una promoción con garantías.

## 1. El CD de test estaba en rojo (y sin CD no hay promoción)

`CVE-2026-14456` — openssl, DoS por crecimiento de memoria sin cota — con
`libcrypto3`/`libssl3` en `3.5.7-r0`. **No es código nuestro**: viene en la
imagen base. El digest de `node:22-alpine` que fijamos ya era el último
publicado, así que subirlo no arreglaba nada: el parche vive en el repositorio
de Alpine, no en la imagen de Node.

Se aplica el mismo `apk upgrade --no-cache` que `Dockerfile.proxy` lleva usando
por este motivo exacto, con su mismo precio declarado: una capa no reproducible.

Verificado sobre las imágenes construidas de verdad:

| | app | worker |
|---|---|---|
| openssl | `3.5.8-r0` | `3.5.8-r0` |
| Trivy `CRITICAL,HIGH` (`os,library`) | **0**, exit 0 | **0**, exit 0 |

## 2. Producción no podía configurar la API de informes

`infra/prod/compose.yml` no cableaba `REPORTS_API_TOKEN` ni su lista de
plataformas. La API habría llegado a producción respondiendo **404 con el token
puesto en Portainer**, sin nada que lo explicara. Se añaden esas dos, más
`VIDEO_MAX_OUTPUT_LONG_SIDE` y `MOODLESHIELD_ENV` (que es lo que distingue test
de prod en la consola, y aquí faltaba).

**Todas con el valor por defecto que producción ya tenía**: el diff de
comportamiento contra lo desplegado hoy es exactamente ninguno.

La plantilla `infra/prod/.env.sample` pasa de documentar **31 de 82** variables
a documentarlas **todas**, al mismo nivel que la de test.

## 3. La causa de fondo: un árbol sin camino de mantenimiento

«Frontera entre entornos» rechazaba toda PR hacia `test` que tocara
`infra/prod/`, y el mensaje de error remitía a «la PR de promoción» — que **no
existe** desde que `cd-promote.yml` mergea solo. Por eso el Compose de
producción envejeció.

La regla pasa a proteger **lo que la promoción escribe de verdad**: las tres
etiquetas `image:` y el ancla `WORKER_ENV_ACTIVATION`. Mover esas líneas desde
una PR sigue rechazándose. El resto del árbol de producción viaja por el carril
normal y llega a prod con su número de versión — más trazable, no menos.

`test/env-example.test.js` deja de estar exento de mirar `infra/prod/`, con una
prueba nueva de que las dos APIs se pueden configurar en **los tres** entornos.

El Compose de prod se sincroniza además con lo que corre en `main` (`v1.0.8`,
ancla `*worker-env*`): en `test` llevaba `v1.0.5` y la antigua.

## Verificación

- `npm run lint` limpio · **464 pruebas, 455 pasan, 0 fallan**, 9 saltadas (las de qpdf/gs)
- Los tres Compose validan con `docker compose config`
- Regla de frontera probada en 4 casos: deja pasar config, corta etiqueta de imagen, corta el ancla, no confunde cabeceras de diff
- **Merge de esta rama en `main` simulado con `merge-tree`: sin conflictos.** Tras el `sed` de la promoción queda `v1.1.0`, ancla `*worker-env*` y las 4 variables dentro; el compose resultante interpola sin errores
- Arranque de producción comprobado con `assertConfigValid` en 4 escenarios:

| Escenario | Resultado |
|---|---|
| Producción **como está hoy** (sin token de informes) | ✅ arranca |
| Con la API de informes encendida | ✅ arranca |
| Token sin su lista de plataformas | 🛑 aborta con mensaje claro |
| Token igual al de contenido | 🛑 aborta con mensaje claro |

## Compatibilidad (Regla 0-bis)

Ningún UUID, secreto, migración ni ruta cambia. No se toca `LAUNCH_RESOURCE_SIGNATURE`.
Las cuatro variables nuevas son opcionales y su valor por defecto **es** el
comportamiento actual de producción. Lo ya insertado en Moodle sigue igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xGYuiYW3TWkojs86Y22Wt