### PR TITLE
fix(visor): el fotograma se enseña entero y la barra de controles se retira sola

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ sueltos. Antes de tocar nada:
 |---|---|
 | [`docs/README.md`](docs/README.md) | **EMPIEZA AQUÍ**: índice, estado del proyecto, hoja de ruta, limitaciones |
 | [`docs/arquitectura.md`](docs/arquitectura.md) | Vista general, árbol de medios, camino de un visionado y de una subida, modelo de datos, endpoints, modelo de seguridad |
-| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…032: por qué cada decisión y cómo revertirla |
+| [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…033: por qué cada decisión y cómo revertirla |
 | [`docs/seguridad.md`](docs/seguridad.md) | Estado de seguridad vigente: qué protege cada capa, dónde está cada hallazgo, límites aceptados y secretos permanentes |
 | [`docs/desarrollo.md`](docs/desarrollo.md) | Entorno, tests, convenciones, trampas, flujo de Git |
 | [`docs/moodle-setup.md`](docs/moodle-setup.md) | Alta de la herramienta en Moodle (6 pasos) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,10 @@ npm run test:integration:local
   `assertVariantsAligned` falla, la culpa casi siempre es del GOP.
 - `frame-ancestors` se calcula de las plataformas registradas; sin ninguna dada
   de alta queda en `'self'` (ver `src/security/frame-ancestors.js`).
+- Un `display: grid` con fila implícita `auto` **no acota** a un hijo con
+  `height: 100%`: crece hasta su alto intrínseco y `overflow: hidden` recorta por
+  abajo (16:9 ≈ 3 %, iPad 1,43:1 ≈ 22 %). `.video-stage` es `display: block` a
+  propósito; lo mide `test/video-stage-layout.test.js`.
 - **Nada de `alert`/`confirm`/`prompt` en `src/ui/`.** Chrome y Edge los
   retiraron de los iframes cross-origin: dentro de Moodle no abren nada y el
   botón que dependa de ellos no hace nada. Usa `<dialog>` y ábrelo siempre por

--- a/README.en.md
+++ b/README.en.md
@@ -316,7 +316,7 @@ All reference documentation is in Spanish.
 |---|---|
 | 🧭 [`docs/README.md`](docs/README.md) | **Documentation index, project status and roadmap** |
 | 🏗️ [`docs/arquitectura.md`](docs/arquitectura.md) | Flows, data model, endpoints, security model |
-| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…032: why each decision, and how to reverse it |
+| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…033: why each decision, and how to reverse it |
 | 🔒 [`docs/seguridad.md`](docs/seguridad.md) | **Current security state**: layers, findings, accepted limits, permanent secrets |
 | 💻 [`docs/desarrollo.md`](docs/desarrollo.md) | **Developer guide**: environment, tests, conventions, debugging |
 | 🎓 [`docs/moodle-setup.md`](docs/moodle-setup.md) | Registering the tool in Moodle, in six steps, with troubleshooting |

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ capa por capa— en [`docs/arquitectura.md`](docs/arquitectura.md).
 |---|---|
 | 🧭 [`docs/README.md`](docs/README.md) | **Índice de la documentación, estado del proyecto y hoja de ruta** |
 | 🏗️ [`docs/arquitectura.md`](docs/arquitectura.md) | Flujos, modelo de datos, endpoints, modelo de seguridad |
-| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…032: por qué cada decisión y cómo revertirla |
+| 🤔 [`docs/decisiones.md`](docs/decisiones.md) | ADR-001…033: por qué cada decisión y cómo revertirla |
 | 🔒 [`docs/seguridad.md`](docs/seguridad.md) | **Estado de seguridad vigente**: capas, hallazgos, límites aceptados y secretos permanentes |
 | 💻 [`docs/desarrollo.md`](docs/desarrollo.md) | **Guía para desarrolladores**: entorno, tests, convenciones, depuración |
 | 🎓 [`docs/moodle-setup.md`](docs/moodle-setup.md) | Alta de la herramienta en Moodle, en seis pasos, con diagnóstico |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ README.md (raíz)  →  este documento  →  arquitectura.md  →  decisiones.md
 | Documento | Qué resuelve |
 |---|---|
 | [`arquitectura.md`](arquitectura.md) | Vista general, árbol de medios, el camino de un visionado y el de una subida, modelo de datos, tabla de endpoints, modelo de seguridad capa por capa |
-| [`decisiones.md`](decisiones.md) | ADR-001…032. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
+| [`decisiones.md`](decisiones.md) | ADR-001…033. Por qué cada decisión, qué alternativas se descartaron y **cómo revertirla** |
 | [`seguridad.md`](seguridad.md) | **Estado de seguridad vigente**: qué protege cada capa, dónde está cada hallazgo, los límites que hay que aceptar por escrito y qué secretos son permanentes |
 
 ### Para trabajar en él
@@ -82,9 +82,9 @@ El manual completo, con los errores que verás y qué significan, está en
 
 ## Estado del proyecto
 
-**Producción: `v1.0.8`** (20 de agosto de 2026) · 21 migraciones en `test` ·
-**448 pruebas unitarias** (439 pasan, 9 se saltan sin las herramientas de la imagen del
-worker) y **176 de integración** contra PostgreSQL real · `npm audit` en 0.
+**Producción: `v1.0.10`** (31 de agosto de 2026) · 21 migraciones en `test` ·
+**480 pruebas unitarias** (471 pasan, 9 se saltan sin las herramientas de la imagen del
+worker) y **177 de integración** contra PostgreSQL real · `npm audit` en 0.
 
 El sistema está **en uso, sirviendo material real**. Lo que sigue no es una lista de
 funcionalidad por construir, sino el mapa de lo que hay:

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -567,6 +567,10 @@ que pliega el panel lateral. Todo lo demás —título del material, lista de la
 colección, Anterior/Siguiente, descarga y línea de estado— vive en ese panel, de
 modo que el alto restante es íntegramente del contenido.
 
+Ese alto se usa para enseñar el fotograma **entero**: el reproductor encaja el
+vídeo con `object-fit: contain`, con franjas negras si su relación de aspecto no
+coincide con la del hueco. Una grabación de iPad (1,43:1) no se recorta.
+
 El chip abre un `<dialog>` con el aviso legal completo y los datos registrados
 de la sesión: nombre, identidad, IP, inicio y caducidad, referencia de
 auditoría, material y navegador. Esa **referencia es el `jti`**, el mismo valor

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -570,6 +570,9 @@ modo que el alto restante es íntegramente del contenido.
 Ese alto se usa para enseñar el fotograma **entero**: el reproductor encaja el
 vídeo con `object-fit: contain`, con franjas negras si su relación de aspecto no
 coincide con la del hueco. Una grabación de iPad (1,43:1) no se recorta.
+Los controles se retiran solos mientras reproduce y vuelven con cualquier
+actividad (ADR-033); la marca de agua y el chip de sesión monitorizada siguen en
+pantalla el 100 % del tiempo.
 
 El chip abre un `<dialog>` con el aviso legal completo y los datos registrados
 de la sesión: nombre, identidad, IP, inicio y caducidad, referencia de

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -1408,3 +1408,57 @@ diseño; con el valor por defecto el caso no se da.
 
 **Cómo revertirlo.** Poner un número en `MAX_FOLDERS_PER_OWNER` del stack. No hay
 nada que desplegar ni que migrar.
+
+## ADR-033 · La barra de controles del vídeo se retira sola durante la reproducción
+
+**Estado**: aceptada · **Fecha**: 2026-09 · Extiende ADR-022
+
+**Contexto.** El 2 de septiembre de 2026, en producción, una grabación de iPad
+(1,43:1) se veía recortada por abajo: el escenario del reproductor era una
+rejilla con fila `auto` y el vídeo la desbordaba (issue #95; un fallo, no una
+decisión). Arreglado el encuadre quedó a la vista lo que el desbordamiento
+tapaba: la barra de controles y su degradado ocupan la franja inferior del vídeo
+**siempre**, también reproduciendo, y en un vídeo limitado por alto —el caso
+normal en un hueco ancho— esa franja es imagen, no fondo. En una pizarra escrita
+hasta el borde son las últimas líneas. El reproductor nació con los controles
+fijos porque nadie lo decidió, no porque se decidiera.
+
+**Decisión.** Reproduciendo, la barra se retira a los tres segundos sin
+actividad y vuelve con el ratón, una tecla que sea un atajo, un toque o el foco.
+Se queda fija —sin temporizador— en pausa, al terminar y antes de empezar, y
+mientras dura un *pin*: arrastrar la línea de tiempo (aunque el puntero salga
+del reproductor), el ratón sobre la barra, foco de teclado dentro de ella
+(`:focus-visible`; el foco que un clic de ratón deja en un botón no cuenta) y la
+ventana flotante. Soltar el último pin re-arma el temporizador, nunca oculta en
+seco; sacar el ratón del reproductor sí. La barra oculta sólo pierde `opacity` y
+`pointer-events`: sigue en el árbol de accesibilidad y en el orden de tabulación,
+y un `:has(:focus-visible)` en CSS la enseña aunque el JavaScript fallara. En
+táctil, un toque con la barra oculta sólo la revela; el segundo pausa. El
+degradado deja de recibir punteros: un clic en él es un clic en el vídeo.
+`prefers-reduced-motion` quita el fundido, no el ocultado. La lógica es una
+máquina de estados pura (`createControlsAutohide`) con el reloj inyectado,
+probada sin DOM; cada reproductor lleva la suya.
+
+**Razones.** Es la convención de todos los reproductores que el alumno usa, y la
+única forma de devolverle la franja inferior sin quitar controles.
+`visibility: hidden` o `display: none` habrían sido más simples, pero sacan los
+botones del Tab y de los lectores de pantalla justo cuando más se necesitan;
+`focus-within` como pin fijaba la barra para siempre, porque cada clic en el
+escenario enfoca el reproductor y Chrome enfoca el botón pulsado; y un listener
+de toque aparte sobraba (`pointerdown` lo cubre) y penaliza el scroll. Revelar
+sin pausar al tocar es lo que hace YouTube en móvil: «mirar por dónde voy» no
+puede detener la clase.
+
+**Consecuencias.** Lo que ADR-022 promete no cambia: el chip «Sesión
+monitorizada» vive en la barra superior, fuera del reproductor, y la marca de
+agua no entra en ningún selector de ocultado; los dos están en pantalla el 100 %
+del tiempo. Nada de lo desplegado se entera: sólo CSS y JavaScript del visor.
+Límite aceptado, el mismo que YouTube o Vimeo: un lector de pantalla que navega
+con cursor virtual, sin mover el foco, puede anunciar botones que no ve;
+cualquier tecla los enseña. Efecto colateral menor del encuadre, no de esta
+decisión: con franjas laterales la marca de agua puede caer en parte sobre fondo
+negro; sigue en el campo visual y la traza forense es el patrón A/B.
+
+**Cómo revertirlo.** Quitar `autohide` de `createVideoView` y las reglas
+`.is-idle` de `app.css`. Lo vigila el test «la barra de controles se retira sola
+sin salir del árbol de accesibilidad» de `test/ui-iframe.test.js`.

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -302,6 +302,16 @@ plataformas antes de probar el launch.
 
 **El keyset lo consulta el PHP de Moodle, no el navegador.** Ver Modo 3.
 
+**Un `display: grid` con fila implícita `auto` no acota a un hijo con `height: 100%`.** El
+porcentaje se resuelve contra el área de rejilla, que todavía no existe cuando se dimensionan
+las pistas, así que cuenta como `auto`: la fila crece hasta el alto intrínseco del vídeo a
+ancho completo y el `overflow: hidden` recorta por abajo. Con 16:9 el corte era del 3 % y pasó
+inadvertido diez versiones; con una grabación de iPad (1,43:1) es del 22 %. La pista que
+despista: la captura de `canvas.drawImage(video, 0, 0, videoWidth, videoHeight)` sale entera
+porque lee el elemento, no el layout. `.video-stage` es `display: block` a propósito, y lo
+mide de verdad `test/video-stage-layout.test.js` con Chrome headless (se salta si no hay
+Chrome; en el runner de CI lo hay).
+
 ---
 
 ## Depurar

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -138,8 +138,8 @@ Salida esperada: dos patrones distintos, del estilo `AABBBAAAAA` y `BBABABBAAB`.
 
 ```bash
 npm run lint              # ESLint
-npm test                  # 453 unitarias, sin base de datos (9 se saltan, ver abajo)
-npm run test:integration  # 176 contra Postgres real
+npm test                  # 480 unitarias, sin base de datos (9 se saltan, ver abajo)
+npm run test:integration  # 177 contra Postgres real
 npm run test:coverage     # cobertura nativa de node:test
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -1058,7 +1058,23 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
   padding: 3rem clamp(.55rem, 1.5vw, 1rem) .45rem;
   background: linear-gradient(to bottom, transparent, rgb(0 0 0 / .78) 58%, rgb(0 0 0 / .92));
   color: #fff;
+  transition: opacity .2s ease;
+  /* El degradado (padding-top 3rem) no intercepta clics ni cuenta como hover: la
+     línea de tiempo y la fila de botones recuperan pointer-events justo debajo.
+     El padding se queda porque .video-time se apoya en él en huecos ≤25rem. */
+  pointer-events: none;
 }
+.video-controls > * { pointer-events: auto; }
+/* Reproduciendo, la barra se retira sola (ADR-033). Sólo opacity + pointer-events:
+   sigue en el árbol de accesibilidad y en el orden de tabulación; nunca
+   visibility:hidden ni display:none. La marca de agua no entra aquí. */
+.video-view.is-idle .video-controls { opacity: 0; }
+.video-view.is-idle .video-controls,
+.video-view.is-idle .video-controls > * { pointer-events: none; }
+/* Cinturón: aunque el JS fallara, un control con foco de teclado nunca queda invisible. */
+.video-view.is-idle .video-controls:has(:focus-visible) { opacity: 1; }
+/* En el root y no en el escenario, para que cubra también :fullscreen. */
+.video-view.is-idle { cursor: none; }
 .video-timeline {
   --played: 0%;
   --buffered: 0%;
@@ -1169,6 +1185,8 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
   .video-view.is-buffering .video-loader { animation: none; }
+  /* La barra se sigue retirando; sólo se va el fundido. */
+  .video-controls,
   .video-center-play,
   .video-timeline::-webkit-slider-thumb,
   .video-icon-button { transition: none; }

--- a/src/ui/assets/app.css
+++ b/src/ui/assets/app.css
@@ -959,13 +959,20 @@ body.is-panel-hidden .viewer-sidebar { display: none; }
 .video-view:focus-visible {
   box-shadow: inset 0 0 0 2px var(--accent);
 }
+/* Bloque, no rejilla. Con `display: grid` la fila implícita `auto` crecía hasta
+   el alto intrínseco del vídeo (ancho ÷ relación de aspecto): el `height: 100%`
+   del <video> se resuelve contra un área de rejilla que aún no existe al
+   dimensionar las pistas, y el `overflow: hidden` recortaba por abajo todo lo
+   que no fuera 16:9 (con una grabación de iPad, 1,43:1, el 22 % del fotograma).
+   Con la caja definida, `object-fit: contain` centra y encaja él solo; los demás
+   hijos son absolutos y `place-items` no hacía nada. Lo mide de verdad
+   test/video-stage-layout.test.js. */
 .video-stage {
   position: relative;
   width: 100%;
   height: 100%;
   min-height: 0;
-  display: grid;
-  place-items: center;
+  display: block;
   overflow: hidden;
   background: #000;
 }

--- a/src/ui/assets/collection.js
+++ b/src/ui/assets/collection.js
@@ -1,4 +1,4 @@
-import { createVideoView } from './video-component.js?v=resume-1'
+import { createVideoView } from './video-component.js?v=video-fit-1'
 import { createPdfView } from './pdf-component.js?v=resume-1'
 import { downloadPdfCopy } from './pdf-download.js?v=viewer-ux-1'
 import { createViewerShell, VIDEO_DOWNLOAD_HELP } from './viewer-shell.js?v=viewer-chrome-1'

--- a/src/ui/assets/player.js
+++ b/src/ui/assets/player.js
@@ -1,4 +1,4 @@
-import { createVideoView } from './video-component.js?v=resume-1'
+import { createVideoView } from './video-component.js?v=video-fit-1'
 import { createViewerShell, VIDEO_DOWNLOAD_HELP } from './viewer-shell.js?v=viewer-chrome-1'
 import { createProgressSaver, videoProgressPosition } from './progress-client.js?v=resume-1'
 import { createVideoTelemetry } from './telemetry-client.js?v=seguimiento-1'

--- a/src/ui/assets/video-component.js
+++ b/src/ui/assets/video-component.js
@@ -77,6 +77,83 @@ export function mediaShortcut (rawKey, { onButton = false } = {}) {
 }
 
 /**
+ * Auto-ocultado de la barra de controles (ADR-033). Pura a propósito: no sabe
+ * qué hora es ni toca el DOM; recibe `schedule`/`cancel` y avisa por `onChange`
+ * sólo en las transiciones visible ↔ oculta.
+ *
+ * En pausa, al terminar o antes de empezar no hay temporizador: la barra queda
+ * fija sin necesidad de pin. Los pins ('scrub', 'hover', 'focus', 'pip') la
+ * mantienen visible mientras duren, y soltar el último re-arma el temporizador
+ * en vez de ocultar en seco: quien suelta la línea de tiempo o sale de la barra
+ * con el ratón tiene `idleMs` de margen.
+ */
+export function createControlsAutohide ({ idleMs = 3000, schedule, cancel, onChange }) {
+  let visible = true
+  let playing = false
+  let timer = null
+  let destroyed = false
+  const pins = new Set()
+
+  const clearTimer = () => {
+    if (timer === null) return
+    cancel(timer)
+    timer = null
+  }
+  // Se re-comprueba al vencer: un cancel que no llegó no puede ocultar una
+  // barra que entre tanto se fijó o se pausó.
+  const tryHide = () => {
+    timer = null
+    if (destroyed || !playing || pins.size > 0 || !visible) return
+    visible = false
+    onChange(false)
+  }
+  const arm = () => {
+    clearTimer()
+    timer = schedule(tryHide, idleMs)
+  }
+  const show = () => {
+    if (destroyed) return
+    if (!visible) {
+      visible = true
+      onChange(true)
+    }
+    if (playing && pins.size === 0) arm()
+    else clearTimer()
+  }
+
+  return {
+    get visible () { return visible },
+    activity: show,
+    setPlaying (next) {
+      if (destroyed) return
+      playing = Boolean(next)
+      show()
+    },
+    pin (reason) {
+      if (destroyed) return
+      pins.add(reason)
+      show()
+    },
+    unpin (reason) {
+      if (destroyed || !pins.delete(reason)) return
+      if (pins.size === 0 && playing) arm()
+    },
+    leave () {
+      if (destroyed) return
+      clearTimer()
+      if (playing && pins.size === 0 && visible) {
+        visible = false
+        onChange(false)
+      }
+    },
+    destroy () {
+      clearTimer()
+      destroyed = true
+    }
+  }
+}
+
+/**
  * Decide qué hacer ante un ERROR de hls.js. Función pura para poder probarla.
  *
  * La distinción importante es el 401/403: hls.js lo clasifica como error de red,
@@ -280,6 +357,29 @@ export function createVideoView ({
   let destroyed = false
   const reducedMotion = win.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
 
+  // La barra se retira sola reproduciendo (ADR-033). `reducedMotion` no la
+  // desactiva: sólo quita el fundido (CSS). Cada reproductor lleva la suya:
+  // una colección crea y destruye varios en la misma página.
+  const autohide = createControlsAutohide({
+    schedule: (fn, ms) => win.setTimeout(fn, ms),
+    cancel: (handle) => win.clearTimeout(handle),
+    onChange: (visible) => root.classList.toggle('is-idle', !visible)
+  })
+  // En táctil, un toque con la barra oculta sólo la revela: «mirar por dónde
+  // voy» no puede pausar el vídeo. Se decide en pointerdown y el click que
+  // llega después se traga en captura, sea cual sea su destino (al revelar, el
+  // botón que aparece bajo el dedo no debe recibirlo).
+  let tapRevealed = false
+  const isFocusVisible = (el) => {
+    try { return el.matches(':focus-visible') } catch { return true }
+  }
+  // El foco fija la barra sólo si es de teclado: el `root.focus()` de cada clic
+  // en el escenario y el foco que Chrome da a un botón pulsado con ratón no cuentan.
+  const syncFocusPin = (target) => {
+    if (controls.contains(target) && isFocusVisible(target)) autohide.pin('focus')
+    else autohide.unpin('focus')
+  }
+
   const listen = (target, type, handler, options) => {
     target.addEventListener(type, handler, options)
     cleanups.push(() => target.removeEventListener(type, handler, options))
@@ -414,6 +514,10 @@ export function createVideoView ({
       pip.setAttribute('aria-label', label)
       pip.title = label
     }
+    // Mientras el vídeo está en la flotante, la zona en línea es un cartel y el
+    // botón de cerrarla tiene que seguir a la vista.
+    if (active) autohide.pin('pip')
+    else autohide.unpin('pip')
   }
 
   const togglePip = async () => {
@@ -450,6 +554,9 @@ export function createVideoView ({
       active ? ICONS.exitFullscreen : ICONS.fullscreen,
       active ? 'Salir de pantalla completa (F)' : 'Pantalla completa (F)'
     )
+    // El layout acaba de cambiar (o se vuelve del fullscreen nativo de iOS, donde
+    // este overlay no existe): que el alumno vea dónde están las cosas.
+    autohide.activity()
   }
 
   const toggleFullscreen = async () => {
@@ -555,12 +662,14 @@ export function createVideoView ({
     centerPlay.setAttribute('aria-label', 'Pausar')
     centerPlay.title = 'Pausar'
     startWatermark()
+    autohide.setPlaying(true)
   }
   const onPause = () => {
     root.classList.remove('is-playing')
     setButton(playPause, element.ended ? ICONS.replay : ICONS.play, element.ended ? 'Volver a reproducir (K)' : 'Reproducir (K)')
     setButton(centerPlay, element.ended ? ICONS.replay : ICONS.play, element.ended ? 'Volver a reproducir' : 'Reproducir')
     stopWatermark()
+    autohide.setPlaying(false)
   }
   const onEnded = () => {
     root.classList.add('has-ended')
@@ -578,11 +687,13 @@ export function createVideoView ({
     if (total === null || !Number.isFinite(next)) return
     element.currentTime = Math.min(total, Math.max(0, next))
     updateTimeline({ preserveThumb: true })
+    autohide.activity()
   }
   const endScrubbing = () => {
     scrubbing = false
     root.classList.remove('is-scrubbing')
     updateTimeline({ preserveThumb: false })
+    autohide.unpin('scrub')
   }
   const onVolumeInput = () => {
     const next = Number(volume.value)
@@ -590,6 +701,7 @@ export function createVideoView ({
     element.volume = Math.min(1, Math.max(0, next))
     element.muted = element.volume === 0
     updateVolume()
+    autohide.activity()
   }
   const onStageClick = (event) => {
     if (event.target !== stage && event.target !== element) return
@@ -611,6 +723,7 @@ export function createVideoView ({
     else if (action === 'toggle-fullscreen') void toggleFullscreen()
     else if (action === 'toggle-pip') void togglePip()
     else return
+    autohide.activity()
     event.preventDefault()
     event.stopPropagation()
   }
@@ -632,6 +745,7 @@ export function createVideoView ({
   listen(timeline, 'pointerdown', () => {
     scrubbing = true
     root.classList.add('is-scrubbing')
+    autohide.pin('scrub')
   })
   listen(timeline, 'input', onTimelineInput)
   listen(timeline, 'change', endScrubbing)
@@ -655,6 +769,49 @@ export function createVideoView ({
   listen(doc, 'fullscreenchange', updateFullscreen)
   listen(element, 'webkitbeginfullscreen', updateFullscreen)
   listen(element, 'webkitendfullscreen', updateFullscreen)
+
+  // Sólo el ratón tiene hover y salida reales: en táctil, pointermove llega al
+  // hacer scroll sobre el vídeo y pointerleave al levantar el dedo.
+  listen(root, 'pointermove', (event) => {
+    if (event.pointerType !== 'touch') autohide.activity()
+  })
+  listen(root, 'pointerdown', (event) => {
+    const wasIdle = !autohide.visible
+    autohide.activity()
+    tapRevealed = event.pointerType === 'touch' && wasIdle &&
+      (event.target === stage || event.target === element)
+  })
+  listen(root, 'click', (event) => {
+    if (!tapRevealed) return
+    tapRevealed = false
+    event.preventDefault()
+    event.stopPropagation()
+  }, true)
+  listen(root, 'pointerleave', (event) => {
+    if (event.pointerType === 'mouse') autohide.leave()
+  })
+  // Llegan aunque .video-controls tenga pointer-events:none: es ancestro del
+  // botón o de la línea de tiempo que recibe el puntero; el degradado no cuenta.
+  listen(controls, 'pointerenter', (event) => {
+    if (event.pointerType === 'mouse') autohide.pin('hover')
+  })
+  listen(controls, 'pointerleave', (event) => {
+    if (event.pointerType === 'mouse') autohide.unpin('hover')
+  })
+  // Aparte del listener de atajos: cualquier tecla con el foco en la barra la
+  // fija (Chrome convierte un foco de ratón en :focus-visible sin nuevo focusin).
+  listen(root, 'keydown', () => {
+    autohide.activity()
+    if (controls.contains(doc.activeElement)) autohide.pin('focus')
+  })
+  listen(root, 'focusin', (event) => {
+    autohide.activity()
+    syncFocusPin(event.target)
+  })
+  // Durante focusout, document.activeElement vale body en Chrome: relatedTarget.
+  listen(root, 'focusout', (event) => {
+    if (!event.relatedTarget || !controls.contains(event.relatedTarget)) autohide.unpin('focus')
+  })
 
   // Disuasión básica: evita el clic derecho → guardar accidental. La protección
   // real no depende de impedir operaciones en el navegador.
@@ -801,6 +958,9 @@ export function createVideoView ({
       if (destroyed) return
       destroyed = true
       stopWatermark()
+      // Antes de retirar los listeners: un temporizador pendiente no puede tocar
+      // un root que ya no está en la página.
+      autohide.destroy()
       for (const cleanup of cleanups.splice(0)) cleanup()
       if (doc.pictureInPictureElement === element) {
         doc.exitPictureInPicture?.().catch?.(() => {})

--- a/test/ui-iframe.test.js
+++ b/test/ui-iframe.test.js
@@ -509,6 +509,20 @@ test('el vídeo ofrece navegación completa, PiP, captura y una marca de agua ca
     'ocultar el volumen no debe eliminar también el botón de silencio')
 })
 
+test('el fotograma se ve entero: el escenario del vídeo no es una rejilla', async () => {
+  // Con `display: grid` la fila implícita `auto` crecía hasta el alto intrínseco
+  // del vídeo y `overflow: hidden` recortaba por abajo el 22 % de una grabación
+  // de iPad. Esta prueba vigila la regla; test/video-stage-layout.test.js mide
+  // el hecho en Chrome headless.
+  const css = await readFile(path.join(uiDir, 'assets/app.css'), 'utf8')
+  assert.match(css, /\.video-stage\s*\{[^}]*display:\s*block/s,
+    'un grid con fila auto deja crecer el vídeo hasta su alto intrínseco y overflow:hidden lo recorta')
+  assert.doesNotMatch(css, /\.video-stage\s*\{[^}]*(display:\s*grid|place-items)/s,
+    'place-items no centraba nada: object-fit:contain ya lo hace dentro de la caja definida')
+  assert.match(css, /\.video-stage video\s*\{[^}]*object-fit:\s*contain/s,
+    'el vídeo se encaja entero, nunca se recorta con cover')
+})
+
 test('el player y los visores se sirven sin CDN', async () => {
   for (const file of await uiFiles('.html')) {
     const html = await readFile(file, 'utf8')

--- a/test/ui-iframe.test.js
+++ b/test/ui-iframe.test.js
@@ -523,6 +523,43 @@ test('el fotograma se ve entero: el escenario del vídeo no es una rejilla', asy
     'el vídeo se encaja entero, nunca se recorta con cover')
 })
 
+test('la barra de controles se retira sola sin salir del árbol de accesibilidad', async () => {
+  // ADR-033. Sólo opacity + pointer-events: un lector de pantalla y el Tab
+  // siguen llegando a los botones; la marca de agua y el chip no se ocultan.
+  const css = await readFile(path.join(uiDir, 'assets/app.css'), 'utf8')
+  assert.match(css, /\.video-view\.is-idle \.video-controls\s*\{[^}]*opacity:\s*0/s,
+    'la barra oculta se retira con opacity')
+  assert.match(css, /\.video-view\.is-idle \.video-controls,\s*\.video-view\.is-idle \.video-controls > \*\s*\{[^}]*pointer-events:\s*none/s,
+    'una barra invisible no puede seguir recibiendo toques')
+  assert.doesNotMatch(css, /\.video-view\.is-idle \.video-controls\s*\{[^}]*(visibility|display)/s,
+    'visibility:hidden o display:none la sacarían del árbol de accesibilidad y del Tab')
+  assert.doesNotMatch(css, /\.is-idle[^{]*watermark/, 'la marca de agua no se oculta nunca')
+  assert.match(css, /\.video-view\.is-idle\s*\{[^}]*cursor:\s*none/s, 'el cursor se va con la barra')
+  assert.match(css, /\.video-controls\s*\{[^}]*pointer-events:\s*none/s,
+    'el degradado no debe interceptar clics ni contar como hover')
+  assert.match(css, /\.video-controls > \*\s*\{[^}]*pointer-events:\s*auto/s,
+    'la línea de tiempo y los botones sí se tocan')
+  assert.match(css, /prefers-reduced-motion: reduce\)\s*\{[^]*?\.video-controls[^}]*transition:\s*none/,
+    'con movimiento reducido se quita el fundido, no el ocultado')
+
+  const code = await readFile(path.join(uiDir, 'assets/video-component.js'), 'utf8')
+  assert.match(code, /export function createControlsAutohide/, 'la máquina tiene que ser pura y probada')
+  assert.match(code, /pointerType/, 'táctil y ratón no se comportan igual')
+  assert.match(code, /:focus-visible/, 'sólo el foco de teclado fija la barra')
+  assert.match(code, /tapRevealed/, 'un toque con la barra oculta sólo la revela')
+  assert.match(code, /autohide\.destroy\(\)/, 'la colección destruye y recrea reproductores')
+  assert.doesNotMatch(code, /touchstart/, 'pointerdown ya cubre el toque; un touchstart penaliza el scroll')
+  assert.doesNotMatch(code, /controls\.(setAttribute\('aria-hidden'|inert)/,
+    'la barra oculta sigue anunciándose')
+
+  const player = await readFile(path.join(uiDir, 'assets/player.js'), 'utf8')
+  const collection = await readFile(path.join(uiDir, 'assets/collection.js'), 'utf8')
+  const version = (src) => src.match(/video-component\.js\?v=([\w-]+)/)?.[1]
+  assert.ok(version(player))
+  assert.equal(version(player), version(collection),
+    'dos ?v= distintos cargan el módulo dos veces, con dos estados')
+})
+
 test('el player y los visores se sirven sin CDN', async () => {
   for (const file of await uiFiles('.html')) {
     const html = await readFile(file, 'utf8')

--- a/test/video-component.test.js
+++ b/test/video-component.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   classifyHlsError,
   classifyNativeError,
+  createControlsAutohide,
   formatMediaTime,
   mediaProgress,
   mediaShortcut,
@@ -104,4 +105,193 @@ test('el HLS nativo re-pide ticket ante errores de red o de origen, con cupo', (
     assert.equal(classifyNativeError(code, { attempts: 2 }).action, 'reticket')
     assert.equal(classifyNativeError(code, { attempts: 3 }).action, 'fatal')
   }
+})
+
+// ---- Auto-ocultado de la barra (ADR-033) ----
+// La máquina recibe schedule/cancel inyectados: sin temporizadores reales ni DOM.
+
+function fakeTimers () {
+  const pending = new Map()
+  let next = 0
+  return {
+    schedule (fn, ms) { const id = ++next; pending.set(id, { fn, ms }); return id },
+    cancel (id) { pending.delete(id) },
+    fire () { const due = [...pending.values()]; pending.clear(); for (const { fn } of due) fn() },
+    pending: () => pending.size,
+    last: () => [...pending.values()].at(-1) ?? null
+  }
+}
+
+function autohideHarness (options = {}) {
+  const timers = fakeTimers()
+  const changes = []
+  const autohide = createControlsAutohide({
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+    onChange: (visible) => changes.push(visible),
+    ...options
+  })
+  return { timers, changes, autohide }
+}
+
+test('la barra nace visible, en pausa y sin avisar', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  assert.equal(autohide.visible, true)
+  assert.deepEqual(changes, [])
+  assert.equal(timers.pending(), 0)
+  autohide.activity()
+  assert.equal(timers.pending(), 0, 'en pausa no hay nada que ocultar')
+  assert.deepEqual(changes, [])
+})
+
+test('al reproducir programa el ocultado con idleMs y sólo oculta una vez', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  assert.equal(timers.last().ms, 3000)
+  const { fn } = timers.last()
+  timers.fire()
+  assert.deepEqual(changes, [false])
+  assert.equal(autohide.visible, false)
+  fn()
+  assert.deepEqual(changes, [false], 'vencer dos veces no avisa dos veces')
+
+  const corto = autohideHarness({ idleMs: 1200 })
+  corto.autohide.setPlaying(true)
+  assert.equal(corto.timers.last().ms, 1200)
+})
+
+test('la actividad revela y reinicia el temporizador; onChange sólo en transiciones', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  timers.fire()
+  autohide.activity()
+  assert.deepEqual(changes, [false, true])
+  assert.equal(timers.pending(), 1)
+  autohide.activity()
+  autohide.activity()
+  assert.equal(timers.pending(), 1, 'cada actividad sustituye el temporizador, no lo apila')
+  assert.deepEqual(changes, [false, true])
+})
+
+test('la pausa fija la barra y cancela el temporizador', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  timers.fire()
+  autohide.setPlaying(true)
+  const { fn } = timers.last()
+  autohide.setPlaying(false)
+  assert.equal(changes.at(-1), true)
+  assert.equal(timers.pending(), 0)
+  autohide.activity()
+  assert.equal(timers.pending(), 0)
+  fn()
+  assert.equal(autohide.visible, true, 'un cancel perdido no puede ocultar en pausa')
+  assert.equal(changes.at(-1), true)
+})
+
+test('al terminar la barra vuelve, y volver a reproducir la vuelve a retirar', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  timers.fire()
+  autohide.setPlaying(false)
+  assert.deepEqual(changes, [false, true])
+  autohide.setPlaying(true)
+  assert.equal(timers.pending(), 1)
+  timers.fire()
+  assert.deepEqual(changes, [false, true, false])
+})
+
+test('un pin mantiene visible aunque venza el temporizador, y revela sin armar', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  const { fn } = timers.last()
+  autohide.pin('hover')
+  assert.equal(timers.pending(), 0)
+  fn()
+  assert.equal(autohide.visible, true)
+  assert.deepEqual(changes, [])
+
+  const oculta = autohideHarness()
+  oculta.autohide.setPlaying(true)
+  oculta.timers.fire()
+  oculta.autohide.pin('focus')
+  assert.equal(oculta.changes.at(-1), true)
+  assert.equal(oculta.timers.pending(), 0, 'con un pin no hay temporizador')
+})
+
+test('sólo al soltar el último pin se re-arma, y soltar nunca oculta en seco', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  autohide.pin('hover')
+  autohide.pin('focus')
+  autohide.unpin('hover')
+  assert.equal(timers.pending(), 0)
+  autohide.unpin('focus')
+  assert.equal(timers.pending(), 1)
+  autohide.unpin('inexistente')
+  assert.equal(timers.pending(), 1)
+  assert.deepEqual(changes, [], 'soltar un pin da idleMs de margen')
+  timers.fire()
+  assert.deepEqual(changes, [false])
+
+  const repetido = autohideHarness()
+  repetido.autohide.setPlaying(true)
+  repetido.autohide.pin('hover')
+  repetido.autohide.pin('hover')
+  repetido.autohide.unpin('hover')
+  assert.equal(repetido.timers.pending(), 1, 'los pins son un conjunto, no un contador')
+})
+
+test('reproducir con el foco en la barra no programa nada', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.pin('focus')
+  autohide.setPlaying(true)
+  assert.equal(timers.pending(), 0)
+  assert.deepEqual(changes, [])
+  autohide.unpin('focus')
+  assert.equal(timers.pending(), 1)
+})
+
+test('el ratón fuera del reproductor oculta en seco sólo reproduciendo y sin pin', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.leave()
+  assert.deepEqual(changes, [], 'en pausa no pasa nada')
+  autohide.setPlaying(true)
+  autohide.pin('scrub')
+  autohide.leave()
+  assert.deepEqual(changes, [], 'arrastrando, el puntero puede salir sin perder la barra')
+  autohide.unpin('scrub')
+  assert.equal(timers.pending(), 1)
+  timers.fire()
+  assert.deepEqual(changes, [false])
+  autohide.leave()
+  assert.deepEqual(changes, [false], 'ya oculta: no repite')
+  autohide.activity()
+  autohide.leave()
+  assert.deepEqual(changes, [false, true, false])
+  assert.equal(timers.pending(), 0)
+})
+
+test('destroy cancela lo pendiente y enmudece', () => {
+  const { timers, changes, autohide } = autohideHarness()
+  autohide.setPlaying(true)
+  const { fn } = timers.last()
+  autohide.destroy()
+  assert.equal(timers.pending(), 0)
+  autohide.activity()
+  autohide.setPlaying(false)
+  autohide.pin('hover')
+  autohide.leave()
+  fn()
+  assert.deepEqual(changes, [])
+  assert.equal(timers.pending(), 0)
+  assert.doesNotThrow(() => autohide.destroy())
+})
+
+test('setPlaying acepta valores no booleanos', () => {
+  const { timers, autohide } = autohideHarness()
+  autohide.setPlaying(1)
+  assert.equal(timers.pending(), 1)
+  autohide.setPlaying(undefined)
+  assert.equal(timers.pending(), 0)
 })

--- a/test/video-stage-layout.test.js
+++ b/test/video-stage-layout.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { accessSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { execFile, spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Guardia de layout del reproductor, medida en un navegador de verdad.
+ *
+ * El recorte del vídeo de iPad (issue #95) no lo cazó ninguna prueba porque
+ * ninguna renderizaba: con `.video-stage` en `display: grid`, la fila implícita
+ * `auto` crecía hasta el alto intrínseco del vídeo y `overflow: hidden` cortaba
+ * por abajo un 22 % del fotograma. Un test de texto sobre el CSS sólo vigila la
+ * regla concreta; éste vigila el hecho: el <video> nunca desborda su hueco, sea
+ * cual sea la relación de aspecto. Se salta sin Chrome, como las de PDF sin qpdf.
+ */
+
+const run = promisify(execFile)
+const cssPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/ui/assets/app.css')
+
+function findChrome () {
+  const candidates = [
+    process.env.CHROME_BIN,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    'google-chrome-stable',
+    'google-chrome',
+    'chromium-browser',
+    'chromium'
+  ].filter(Boolean)
+  for (const candidate of candidates) {
+    if (candidate.includes('/')) {
+      try { accessSync(candidate); return candidate } catch { continue }
+    }
+    if (spawnSync(candidate, ['--version'], { stdio: 'ignore' }).status === 0) return candidate
+  }
+  return null
+}
+
+const chrome = findChrome()
+const skip = chrome ? false : 'no hay Chrome ni Chromium (CHROME_BIN): la guardia de layout necesita un motor de renderizado'
+
+/** Un elemento reemplazado con relación de aspecto, sin necesidad de un vídeo real. */
+function poster (width, height) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"><rect width="${width}" height="${height}" fill="#888"/></svg>`
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}
+
+function extractRule (css, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = css.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{[^}]*\\}`))
+  assert.ok(match, `no se encuentra la regla «${selector}» en app.css`)
+  return match[0]
+}
+
+test('el vídeo nunca desborda su hueco, sea cual sea la relación de aspecto', { skip, timeout: 90_000 }, async () => {
+  const css = await readFile(cssPath, 'utf8')
+  // Sólo las reglas del escenario: el hueco lo fija el test, como lo fija el
+  // visor (cadena de alturas definida hasta #content).
+  const rules = [extractRule(css, '.video-stage'), extractRule(css, '.video-stage video')].join('\n')
+  const cases = [
+    { id: 'ipad-en-hueco-ancho', box: [1000, 545], media: [1430, 1000] },
+    { id: 'panoramico-en-hueco-alto', box: [600, 600], media: [1000, 425] },
+    { id: 'dieciseis-nueve', box: [1000, 545], media: [1280, 720] }
+  ]
+  const html = `<!doctype html><meta charset="utf-8"><style>
+body { margin: 0 }
+.hueco { margin-bottom: 8px }
+${rules}
+</style>
+${cases.map((c) => `<div class="hueco" id="${c.id}" style="width:${c.box[0]}px;height:${c.box[1]}px"><div class="video-stage"><video poster="${poster(...c.media)}"></video></div></div>`).join('\n')}
+<pre id="out"></pre>
+<script>
+setTimeout(() => {
+  const out = {}
+  for (const hueco of document.querySelectorAll('.hueco')) {
+    const stage = hueco.querySelector('.video-stage').getBoundingClientRect()
+    const video = hueco.querySelector('video').getBoundingClientRect()
+    out[hueco.id] = { stage: [stage.width, stage.height], video: [video.width, video.height], top: video.top - stage.top }
+  }
+  document.getElementById('out').textContent = JSON.stringify(out)
+}, 1000)
+</script>`
+
+  // Sin `--user-data-dir`: con un perfil propio Chrome no termina tras volcar el
+  // DOM y la prueba muere por timeout (medido: 45 s frente a 2 s). El perfil
+  // temporal que crea él solo se limpia al salir.
+  const { stdout } = await run(chrome, [
+    '--headless=new', '--disable-gpu', '--no-sandbox', '--no-first-run', '--no-default-browser-check',
+    '--window-size=1200,2400', '--virtual-time-budget=4000',
+    '--dump-dom', `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+  ], { timeout: 60_000, maxBuffer: 8 * 1024 * 1024 })
+
+  const measured = stdout.match(/<pre id="out">(\{.*?\})<\/pre>/s)
+  assert.ok(measured, 'Chrome no devolvió las medidas (¿no llegó a ejecutar el script?)')
+  const result = JSON.parse(measured[1])
+  for (const { id, box } of cases) {
+    const { stage, video, top } = result[id]
+    assert.deepEqual(stage.map(Math.round), box, `${id}: el escenario no mide lo que su hueco`)
+    assert.deepEqual(video.map(Math.round), box,
+      `${id}: el <video> mide ${video.map(Math.round).join('×')} en un hueco de ${box.join('×')}: desborda y overflow:hidden lo recorta`)
+    assert.equal(Math.round(top), 0, `${id}: el <video> no empieza en el borde del escenario`)
+  }
+})


### PR DESCRIPTION
Closes #95

## Qué cambia

Dos commits, el primero revertible solo:

1. **`fix(visor)`** — `.video-stage` deja de ser una rejilla (`display: block`). Con `display: grid` la fila implícita `auto` crecía hasta el alto intrínseco del vídeo y `overflow: hidden` recortaba por abajo: 3 % con 16:9 (nunca se notó), 22 % con una grabación de iPad (1,43:1). Con la caja definida, `object-fit: contain` centra y encaja él solo. Lo mide de verdad `test/video-stage-layout.test.js` con Chrome headless (2 s; se salta si no hay Chrome) y lo vigila como texto `test/ui-iframe.test.js`. Trampa nueva en `docs/desarrollo.md` y `CLAUDE.md`.
2. **`feat(visor)`** — la barra de controles se retira sola a los 3 s de reproducción y vuelve con el ratón, un atajo, un toque o el foco; fija en pausa/fin, arrastrando la línea de tiempo, con el ratón encima, con foco de teclado (`:focus-visible`) y en PiP. Sólo `opacity` + `pointer-events` (sigue en el árbol de accesibilidad y en el Tab); la marca de agua y el chip no se ocultan nunca. En táctil, un toque con la barra oculta sólo la revela. Máquina de estados pura probada sin DOM; ADR-033.

**No hay que regenerar ningún vídeo**: la captura marcada ya salía completa porque lee el elemento, no el layout.

## Qué le pasa a lo que ya está puesto y en uso

Nada: sólo CSS y JavaScript del visor, que viajan en la propia imagen. Ninguna actividad hay que reinsertar; sin migración, sin cambio de UUID, de secretos ni de contrato.

- [x] Ninguna actividad Moodle ya insertada deja de abrirse.
- [x] Ningún UUID lógico de material cambia.
- [x] No se edita ninguna migración ya aplicada; si hay esquema, es una migración nueva y aditiva.
- [x] No se rota ningún secreto existente (`WATERMARK_SECRET`, `SESSION_SECRET`, `MEDIA_KEY_SECRET`, `MEDIA_LINK_SECRET`).

## Cómo se ha probado

```
npm run lint              # limpio
npm test                  # tests 480 · pass 471 · fail 0 · skipped 9 (PDF/forense sin qpdf/gs)
                          # incluida «el vídeo nunca desborda su hueco…» ejecutada en Chrome 152 (2,0 s)
npm run test:integration  # tests 177 · pass 177 · fail 0
```

Medida directa de la causa (Chrome headless, hueco 1000×545, vídeo 1430×1000): con la rejilla el `<video>` mide 1000×699 (desborda 154 px, alineado arriba); con `display: block`, 1000×545.

Lo que no se ha podido probar aquí: el reproductor completo exige un launch LTI, así que el comportamiento en Moodle, en Safari y en iPhone se prueba en test (abajo).

## Qué mirar en test antes de promocionar

Con el vídeo real del iPad (y, si se puede, uno 16:9), en el visor suelto **y** dentro de una colección, en el iframe de Moodle y en ventana nueva:

- **Encuadre**: el fotograma entero, con franjas negras laterales en escritorio (arriba/abajo en móvil vertical); nada cortado con el panel plegado ni en pantalla completa. En DevTools, `document.querySelector('.video-stage video').getBoundingClientRect().height` coincide con el de `.video-stage` (hoy en prod es mayor).
- **Barra**: reproduciendo desaparece a los ~3 s (barra, degradado y cursor) y vuelve al mover el ratón, pulsar un atajo o tocar; se queda con el ratón encima, arrastrando la línea de tiempo aunque el puntero salga, con Tab dentro de la barra, en pausa/fin y en PiP; sacar el ratón del reproductor la oculta; un clic de ratón en Pausa/Play no la fija.
- **Táctil (iPad/iPhone)**: un toque con la barra oculta sólo la revela; el segundo pausa; el scroll sobre el vídeo no la hace parpadear; tocar un botón no la esconde al levantar el dedo. Fullscreen nativo de iPhone: pausar allí y salir → barra visible.
- **Siempre visibles**: la marca de agua y el chip «Sesión monitorizada». Colección: cambiar de material varias veces sin errores en consola.
- La captura marcada sigue saliendo completa (no es evidencia del arreglo).

Repo público: en las capturas para cerrar el issue, tapar DNI y nombre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JsDgVp2jYrTaYoaqVTrTC
