### PR TITLE
fix(pdf): el worker acepta los avisos inofensivos de qpdf en vez de dar el PDF por dañado

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,13 @@ npm run test:integration:local
   botón que dependa de ellos no hace nada. Usa `<dialog>` y ábrelo siempre por
   el helper que limpia `returnValue`, porque ese valor sobrevive entre aperturas
   y cerrar con Escape no lo toca. Lo vigila `test/ui-iframe.test.js`.
-- Las 8 pruebas de PDF —y una del lector forense— se saltan sin
+- Las 9 pruebas de PDF —y una del lector forense— se saltan sin
   `qpdf`/`pdfinfo`/`gs`/`ffmpeg`: viven en la imagen del worker. El comando de
   Docker para ejecutarlas de verdad está en
-  [`docs/desarrollo.md`](docs/desarrollo.md#las-9-pruebas-que-se-saltan-solas).
+  [`docs/desarrollo.md`](docs/desarrollo.md#las-10-pruebas-que-se-saltan-solas).
+- **`qpdf --check` sale con 3 cuando hay avisos sin errores**, y avisa también
+  de cosas inofensivas: el Quartz de macOS deja entradas xref «en uso» a offset
+  0 y así llegó a producción un PDF de 51 páginas que el worker rechazó como
+  dañado (#97). `checkStructure` sólo acepta los avisos de una lista corta,
+  porque qpdf también «repara» un fichero truncado y lo cuenta como avisos. Un
+  aviso nuevo se rechaza con su texto en el log: léelo antes de ampliar la lista.

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -374,6 +374,14 @@ item de Deep Linking usa un icono genérico y nunca la primera página, que podr
 ser justo el material sensible. Las pruebas de la cadena se ejecutan dentro de una
 imagen con esas herramientas, no en el runner de CI.
 
+*Nota (2026-09-05, #97).* `qpdf --check` distingue avisos (código 3) de errores
+(código 2), y el primer filtro se quedaba con cualquiera de los dos como «dañado».
+Desde entonces acepta el código 3 sólo cuando todos los avisos están en una lista
+corta de patrones inofensivos verificados —hoy, las entradas xref a offset 0 que
+deja el Quartz de macOS—, y rechaza el resto con el texto del aviso. No se
+relaja más porque qpdf también repara un fichero truncado y lo cuenta como
+avisos; publicarlo sería publicar páginas de menos sin que nadie lo notara.
+
 ---
 
 ## ADR-015 · Carpetas personales por profesor, no por institución

--- a/docs/desarrollo.md
+++ b/docs/desarrollo.md
@@ -168,9 +168,9 @@ npm run test:integration
 npm run test:integration:local
 ```
 
-### Las 9 pruebas que se saltan solas
+### Las 10 pruebas que se saltan solas
 
-Ocho son de la cadena de PDF y una del lector forense con vídeo real. Necesitan `qpdf`,
+Nueve son de la cadena de PDF y una del lector forense con vídeo real. Necesitan `qpdf`,
 `pdfinfo`, `ghostscript` o `ffmpeg`, que viven en la imagen del worker y no necesariamente
 en tu Mac. Para ejecutar las de PDF de verdad:
 
@@ -295,6 +295,18 @@ Escape no lo toca. Lo vigila `test/ui-iframe.test.js`.
 
 **Moodle nunca avisa de que se borró una actividad.** No existe callback. Cualquier diseño
 que asuma lo contrario está mal.
+
+**`qpdf --check` sale con 3 cuando hay avisos sin errores**, y avisa también de cosas
+inofensivas. El Quartz de macOS deja entradas de la xref «en uso» a offset 0 sin objeto
+detrás (`object has offset 0 - a common error handled correctly by qpdf`), y así llegó a
+producción un PDF de 51 páginas que el worker rechazó como dañado
+([#97](https://github.com/jamataran/moodleshield/issues/97)). `checkStructure` en
+`src/media/pdf.js` acepta el código 3 **sólo** si todos los avisos están en una lista corta
+de patrones verificados; cualquier otro sigue siendo `corrupt_pdf`, ahora con el texto del
+aviso en el mensaje. No lo relajes con `--warning-exit-0`: qpdf también «repara» un fichero
+truncado reconstruyendo la xref y lo cuenta como avisos, y las páginas que faltan se
+publicarían sin que nadie lo notara. Un aviso nuevo se lee en el log y, si es inofensivo, se
+añade a la lista con una fixture que lo reproduzca.
 
 **`frame-ancestors` se calcula de las plataformas registradas.** Sin ninguna dada de alta
 queda en `'self'`: Moodle no podrá embeber la herramienta. En producción, registra las

--- a/src/media/pdf.js
+++ b/src/media/pdf.js
@@ -37,12 +37,33 @@ function timeout () {
 /** Un PDF con contraseña hace fallar a casi todas las herramientas por igual. */
 const ENCRYPTED_RE = /encrypt|password|contrase|cifrad/i
 
+/**
+ * qpdf sale con 3 cuando ha encontrado avisos pero ningún error. Sólo se
+ * aceptan los avisos cuya inocuidad está comprobada; el resto sigue siendo
+ * «dañado». La lista es corta a propósito: qpdf también «repara» un fichero
+ * truncado reconstruyendo la xref y lo cuenta como avisos, y ese sí hay que
+ * rechazarlo, porque las páginas que faltan se publicarían sin que nadie lo
+ * notara (pdfinfo tampoco las vería, y la comparación de páginas no saltaría).
+ *
+ * - `object has offset 0`: entradas de la xref marcadas «en uso» sin objeto
+ *   detrás. Las deja el Quartz de macOS al descartar objetos durante la
+ *   exportación; qpdf las trata como `null` y no se pierde contenido.
+ */
+const BENIGN_WARNINGS = [/object has offset 0/]
+const QPDF_WARNINGS_OK = 3
+
+function warningLines (stderr) {
+  return String(stderr).split('\n').map((line) => line.trim()).filter((line) => line.startsWith('WARNING:'))
+}
+
 /** Estructura del fichero. `qpdf --check` recorre el xref y los objetos. */
-async function checkStructure (file, signal) {
+async function checkStructure (file, signal, log) {
+  let result
   try {
-    await runProcess(config.pdf.qpdfPath, ['--check', '--no-warn', file], {
+    result = await runProcess(config.pdf.qpdfPath, ['--check', file], {
       signal,
-      timeoutMs: timeout()
+      timeoutMs: timeout(),
+      acceptExitCodes: [0, QPDF_WARNINGS_OK]
     })
   } catch (err) {
     // Un PDF cifrado también hace fallar `--check`, y decirle al profesor que
@@ -54,10 +75,26 @@ async function checkStructure (file, signal) {
       )
     }
     throw new PdfValidationError(
-      `El PDF está dañado o su estructura no es válida: ${firstLine(err.message)}`,
+      `El PDF está dañado o su estructura no es válida: ${detail(err.message)}`,
       { code: 'corrupt_pdf' }
     )
   }
+  if (result.code !== QPDF_WARNINGS_OK) return
+
+  const warnings = warningLines(result.stderr)
+  const suspicious = warnings.find((line) => !BENIGN_WARNINGS.some((re) => re.test(line)))
+  // Código 3 sin ningún aviso legible también se rechaza: no se acepta lo que
+  // no se puede explicar.
+  if (suspicious || warnings.length === 0) {
+    throw new PdfValidationError(
+      `El PDF está dañado o su estructura no es válida: ${suspicious ?? 'qpdf avisó sin detalle'}`,
+      { code: 'corrupt_pdf' }
+    )
+  }
+  log?.warn(
+    { file: path.basename(file), warnings: warnings.length, sample: warnings.slice(0, 3) },
+    'qpdf aceptó el PDF con avisos benignos'
+  )
 }
 
 /**
@@ -72,7 +109,7 @@ async function inspect (file, signal) {
       timeoutMs: timeout()
     }))
   } catch (err) {
-    throw new PdfValidationError(`No se pudo leer el PDF: ${firstLine(err.message)}`, {
+    throw new PdfValidationError(`No se pudo leer el PDF: ${detail(err.message)}`, {
       code: 'unreadable_pdf'
     })
   }
@@ -133,7 +170,7 @@ async function normalize (input, output, signal) {
     ], { signal, timeoutMs: timeout() })
   } catch (err) {
     throw new PdfValidationError(
-      `No se pudo normalizar el PDF: ${firstLine(err.message)}`,
+      `No se pudo normalizar el PDF: ${detail(err.message)}`,
       { code: 'normalize_failed' }
     )
   }
@@ -167,8 +204,17 @@ async function renderPoster (input, outputDir, signal) {
   }
 }
 
-function firstLine (message) {
-  return String(message).split('\n').find((line) => line.trim()) ?? 'sin detalle'
+/**
+ * La línea de `stderr` que explica el fallo. `runProcess` encabeza el mensaje
+ * con «terminó con código N:», que no dice nada; y qpdf imprime primero los
+ * avisos y al final el error, que es la línea que importa. Antes se tomaba la
+ * primera línea a secas y el log de producción acabó diciendo «código 3:» y
+ * nada más.
+ */
+function detail (message) {
+  const lines = String(message).split('\n').map((line) => line.trim()).filter(Boolean)
+  const body = lines.filter((line) => !/terminó con código \d+:$/.test(line))
+  return body.find((line) => !line.startsWith('WARNING:')) ?? body[0] ?? lines[0] ?? 'sin detalle'
 }
 
 async function sha256File (file) {
@@ -197,7 +243,7 @@ export async function processDocumentRevision ({
   const log = logger.child({ documentId, revisionId })
   await mkdir(outputDir, { recursive: true })
 
-  await checkStructure(sourcePath, signal)
+  await checkStructure(sourcePath, signal, log)
   const info = await inspect(sourcePath, signal)
   log.info({ pages: info.pageCount }, 'PDF validado')
 
@@ -207,7 +253,7 @@ export async function processDocumentRevision ({
   // Segunda pasada sobre el fichero ya normalizado: Ghostscript también puede
   // producir algo que qpdf no acepte, y publicar eso sería publicar un PDF que
   // el visor no abrirá.
-  await checkStructure(normalized, signal)
+  await checkStructure(normalized, signal, log)
   const normalizedInfo = await inspect(normalized, signal)
   if (normalizedInfo.pageCount !== info.pageCount) {
     throw new PdfValidationError(

--- a/src/media/run.js
+++ b/src/media/run.js
@@ -15,7 +15,13 @@ export function runProcess (command, args, {
   onLine,
   signal,
   timeoutMs = 0,
-  nice = config.transcode.niceness
+  nice = config.transcode.niceness,
+  /**
+   * Códigos de salida que no son un fallo. qpdf devuelve 3 cuando ha
+   * encontrado avisos sin errores, y quien lo llama tiene que leer `stderr`
+   * para decidir si esos avisos son aceptables: por eso se devuelve `code`.
+   */
+  acceptExitCodes = [0]
 } = {}) {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) return reject(signal.reason ?? new Error('Proceso cancelado'))
@@ -95,7 +101,7 @@ export function runProcess (command, args, {
         return reject(new Error(`${command} superó el límite de ${Math.round(timeoutMs / 1000)} s y se detuvo`))
       }
       if (aborted) return reject(signal?.reason ?? new Error('Proceso cancelado'))
-      if (code === 0) return resolve({ stdout, stderr })
+      if (acceptExitCodes.includes(code)) return resolve({ code, stdout, stderr })
       reject(new Error(`${command} terminó con código ${code}:\n${stderr.slice(-2000)}`))
     })
   })

--- a/test/pdf-processing.test.js
+++ b/test/pdf-processing.test.js
@@ -71,6 +71,21 @@ function buildPdf (pages = 1) {
   return Buffer.from(body, 'latin1')
 }
 
+/**
+ * Lo que deja el Quartz de macOS cuando descarta objetos al exportar: la xref
+ * anuncia `phantoms` objetos más, «en uso» y a offset 0, sin nada detrás. qpdf
+ * lo acepta con avisos (código 3), y así llegó a producción un PDF de 51
+ * páginas que el worker rechazó como dañado (issue #97).
+ */
+function withPhantomObjects (pdf, phantoms = 2) {
+  const text = pdf.toString('latin1')
+  const size = Number(/\/Size (\d+)/.exec(text)[1])
+  return Buffer.from(text
+    .replace(`xref\n0 ${size}\n`, `xref\n0 ${size + phantoms}\n`)
+    .replace('trailer\n', `${'0000000000 00000 n \n'.repeat(phantoms)}trailer\n`)
+    .replace(`/Size ${size}`, `/Size ${size + phantoms}`), 'latin1')
+}
+
 async function withWorkspace (fn) {
   const dir = await mkdtemp(path.join(tmpdir(), 'moodleshield-pdf-'))
   try {
@@ -134,6 +149,19 @@ test('se genera portada, y nunca se publica en el content item', { skip }, async
   })
 })
 
+test('un PDF con entradas xref a offset 0 (Quartz de macOS) se procesa entero', { skip }, async () => {
+  await withWorkspace(async (dir) => {
+    const source = path.join(dir, 'quartz.pdf')
+    const output = path.join(dir, 'staging')
+    await writeFile(source, withPhantomObjects(buildPdf(3), 2))
+
+    const meta = await run(DOC, REV, source, output)
+    assert.equal(meta.pageCount, 3, 'los objetos fantasma no son páginas')
+    const normalized = await readFile(documentPath(output))
+    assert.ok(normalized.subarray(0, 5).toString() === '%PDF-')
+  })
+})
+
 test('un PDF truncado termina en error permanente', { skip }, async () => {
   await withWorkspace(async (dir) => {
     const source = path.join(dir, 'roto.pdf')
@@ -146,6 +174,12 @@ test('un PDF truncado termina en error permanente', { skip }, async () => {
         assert.ok(err instanceof PdfValidationError, `tipo inesperado: ${err.name}`)
         // Un fichero corrupto no mejora reintentándolo tres veces.
         assert.equal(err.permanent, true)
+        assert.equal(err.code, 'corrupt_pdf')
+        // qpdf «repara» un truncado reconstruyendo la xref y lo cuenta como
+        // avisos; el que sean avisos no lo convierte en aceptable. Y el motivo
+        // tiene que quedar escrito: «código 3:» a secas no le sirve a nadie.
+        assert.match(err.message, /dañado.*: .*\S/, `mensaje sin detalle: ${err.message}`)
+        assert.doesNotMatch(err.message, /terminó con código \d+:$/)
         return true
       }
     )


### PR DESCRIPTION
Closes #97.

## Qué pasaba

En producción (5-09-2026) un PDF de 51 páginas exportado desde macOS (productor `Quartz PDFContext`) se rechazó como dañado, de forma permanente:

```
PdfValidationError: El PDF está dañado o su estructura no es válida: qpdf terminó con código 3:
```

El fichero está bien. Quartz deja 17 entradas de la xref «en uso» a offset 0 sin objeto detrás; qpdf lo avisa como «a common error handled correctly by qpdf and most other applications» y sale con **3 = avisos sin errores**. `checkStructure` trataba cualquier código distinto de 0 como corrupción, y `--no-warn` borraba el texto que lo explicaba.

## Qué cambia

- `checkStructure` acepta el código 3 **sólo** si todos los avisos están en una lista corta de patrones verificados (hoy, `object has offset 0`), y los registra a nivel `warn`. Cualquier otro aviso, y cualquier error, sigue siendo `corrupt_pdf`, ahora **con la línea de qpdf que lo explica** en el mensaje.
- No se usa `--warning-exit-0`: qpdf también «repara» un fichero truncado reconstruyendo la xref y lo cuenta como avisos, y las páginas que faltan se publicarían sin que nadie lo notara (pdfinfo tampoco las vería, así que la comparación de páginas no saltaría). Verificado con una fixture truncada: con el flag pasa con 0.
- `runProcess` gana `acceptExitCodes` y devuelve `code`.
- Fixture nueva que reproduce la xref de Quartz y debe procesarse entera; la del truncado exige además que el mensaje lleve el motivo.
- Trampa en `CLAUDE.md` y `docs/desarrollo.md`, nota en ADR-014. El recuento de pruebas que se saltan pasa a 10.

## Regla 0-bis

Nada de lo desplegado se entera: sin migración, sin UUID, sin secretos, sin contrato. Sólo deja entrar ficheros que hoy se rechazan. La revisión fallida en producción no se recupera sola: el profesor vuelve a subir el fichero cuando esté promocionado.

## Evidencia

Dentro de la imagen del worker (`moodleshield/worker:local`, qpdf 12.3.2), mismo paso que ejecuta CI:

```
✔ un PDF con entradas xref a offset 0 (Quartz de macOS) se procesa entero
✔ un PDF truncado termina en error permanente
ℹ tests 9 · pass 9 · skipped 0
```

El PDF real de producción por `processDocumentRevision`, con el log del aviso benigno:

```
{"level":40,"file":"modelo.pdf","warnings":17,"sample":["WARNING: … (object 7 0): object has offset 0 …"],"msg":"qpdf aceptó el PDF con avisos benignos"}
{"pages":51,"bytes":934274,"poster":true}
```

Mensajes que quedan ahora para lo que sí se rechaza:

```
truncado → corrupt_pdf | El PDF está dañado o su estructura no es válida: WARNING: …: file is damaged
no-PDF   → corrupt_pdf | El PDF está dañado o su estructura no es válida: qpdf: …: unable to find trailer dictionary while recovering damaged file
```

`npm run lint` y `npm test` en verde (481 pruebas, 10 saltadas por herramientas).

Pendiente para cerrar el issue: subir el PDF real en **test** y verlo abrirse en el visor; después, el mismo fichero original en **prod** tras promocionar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHSfDgpktjtvGDG4ckxFBe
